### PR TITLE
Support for alternative ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Now you can start a development server as follows:
 
     npm run dev
 
-The application is now running and accessible at http://localhost:8080.
+The application is now running and accessible at http://localhost:8080. Use the `--port` argument for alternative ports, e.g. `npm run dev --port=8081`.
 
 #### Deploying to Production
 

--- a/app/package.json
+++ b/app/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "test": "eslint . && node scripts/test.js",
     "build": "node scripts/build.js",
-    "dev": "webpack serve --mode development"
+    "dev": "webpack serve --mode development --port=$npm_config_port"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.34",


### PR DESCRIPTION
Added support to change the listening port of Secvisogram: E.g.: `npm run dev --port=8081`

This is helpful, if the default port 8080 is already in use on the local development machine, or in case you want to have several instances of Secvisogram to run in parallel.