### PR TITLE
Schema update

### DIFF
--- a/PREVIEW-TEMPLATING.md
+++ b/PREVIEW-TEMPLATING.md
@@ -128,7 +128,9 @@ This is the full list of document properties. It reflects the structure as defin
 | `document.tracking.current_release_date` | The date when the current revision of this document was released | |
 | `document.tracking.generator` | Is a container to hold all elements related to the generation of the document. These items will reference when the document was actually created, including the date it was generated and the entity that generated it. | |
 | `document.tracking.generator.date` | This SHOULD be the current date that the document was generated. Because documents are often generated internally by a document producer and exist for a nonzero amount of time before being released, this field MAY be different from the Initial Release Date and Current Release Date. | |
-| `document.tracking.generator.engine` | This string SHOULD represent the name of the engine that generated the CSAF document, and MAY additionally refer to its version. | TVCE, Red Hat rhsa-to-cvrf 2.1, CMPFA Core Converter CVRF->CSAF Version 0.6 |
+| `document.tracking.generator.engine` | Contains information about the engine that generated the CSAF document. | |
+| `document.tracking.generator.engine.name` | Represents the name of the engine that generated the CSAF document. | Red Hat rhsa-to-cvrf, Secvisogram, TVCE |
+| `document.tracking.generator.engine.version` | Contains the version of the engine that generated the CSAF document. | 0.6.0, 2, 1.0.0-beta+exp.sha.a1c44f85 |
 | `document.tracking.id` | The ID is a simple label that provides for a wide range of numbering values, types, and schemes. Its value SHOULD be assigned and maintained by the original document issuing authority. | Example Company - 2019-YH3234, RHBA-2019:0024, cisco-sa-20190513-secureboot |
 | `document.tracking.initial_release_date` | The date when this document was first published. | |
 | `document.tracking.revision_history` | Holds one revision item for each version of the CSAF document, including the initial one.| |
@@ -158,7 +160,9 @@ This is the full list of document properties. It reflects the structure as defin
 | `product_tree.branches[].branches[].branches[].product.product_identification_helper.cpe` | The Common Platform Enumeration (CPE) attribute refers to a method for naming platforms external to this specification. | |
 | `product_tree.branches[].branches[].branches[].product.product_identification_helper.hashes` | Contains a list of cryptographic hashes usable to identify files.| |
 | `product_tree.branches[].branches[].branches[].product.product_identification_helper.purl` | The package URL (purl) attribute refers to a method for reliably identifying and locating software packages external to this specification. | |
+| `product_tree.branches[].branches[].branches[].product.product_identification_helper.sbom_urls` | Contains a list of URLs where SBOMs for this product can be retrieved.| |
 | `product_tree.branches[].branches[].branches[].product.product_identification_helper.serial_numbers` | Contains a list of parts, or full serial numbers.| |
+| `product_tree.branches[].branches[].branches[].product.product_identification_helper.skus` | Contains a list of parts, or full stock keeping units.| |
 | `product_tree.branches[].branches[].branches[].product.product_identification_helper.x_generic_uris` | Contains a list of identifiers which are either vendor-specific or derived from a standard not yet supported.| |
 | `product_tree.branches[].branches[].category` | Describes the characteristics of the labeled branch. | |
 | `product_tree.branches[].branches[].name` | Contains the canonical descriptor or 'friendly name' of the branch. | Microsoft, Siemens, Windows, Office, SIMATIC, 10, 365, PCS 7 |
@@ -172,8 +176,12 @@ This is the full list of document properties. It reflects the structure as defin
 | `product_tree.branches[].branches[].product.product_identification_helper.hashes[].file_hashes` | Contains a list of cryptographic hashes for this file.| |
 | `product_tree.branches[].branches[].product.product_identification_helper.hashes[].filename` | Contains the name of the file which is identified by the hash values. | WINWORD.EXE, msotadddin.dll, sudoers.so |
 | `product_tree.branches[].branches[].product.product_identification_helper.purl` | The package URL (purl) attribute refers to a method for reliably identifying and locating software packages external to this specification. | |
+| `product_tree.branches[].branches[].product.product_identification_helper.sbom_urls` | Contains a list of URLs where SBOMs for this product can be retrieved.| |
+| `product_tree.branches[].branches[].product.product_identification_helper.sbom_urls[]` | Contains a URL of one SBOM for this product. | |
 | `product_tree.branches[].branches[].product.product_identification_helper.serial_numbers` | Contains a list of parts, or full serial numbers.| |
 | `product_tree.branches[].branches[].product.product_identification_helper.serial_numbers[]` | Contains a part, or a full serial number of the component to identify. | |
+| `product_tree.branches[].branches[].product.product_identification_helper.skus` | Contains a list of parts, or full stock keeping units.| |
+| `product_tree.branches[].branches[].product.product_identification_helper.skus[]` | Contains a part, or a full stock keeping unit (SKU) which is used in the ordering process to identify the component. | |
 | `product_tree.branches[].branches[].product.product_identification_helper.x_generic_uris` | Contains a list of identifiers which are either vendor-specific or derived from a standard not yet supported.| |
 | `product_tree.branches[].branches[].product.product_identification_helper.x_generic_uris[]` | Provides a generic extension point for any identifier which is either vendor-specific or derived from a standard not yet supported. | |
 | `product_tree.branches[].branches[].product.product_identification_helper.x_generic_uris[].namespace` | Refers to a URL which provides the name and knowledge about the specification used or is the namespace in which these values are valid. | |
@@ -193,8 +201,12 @@ This is the full list of document properties. It reflects the structure as defin
 | `product_tree.branches[].product.product_identification_helper.hashes[].file_hashes[].value` | Contains the cryptographic hash value in hexadecimal representation. | 4775203615d9534a8bfca96a93dc8b461a489f69124a130d786b42204f3341cc, 9ea4c8200113d49d26505da0e02e2f49055dc078d1ad7a419b32e291c7afebbb84badfbd46dec42883bea0b2a1fa697c, 37df33cb7464da5c7f077f4d56a32bc84987ec1d85b234537c1c1a4d4fc8d09dc29e2e762cb5203677bf849a2855a0283710f1f5fe1d6ce8d5ac85c645d0fcb3 |
 | `product_tree.branches[].product.product_identification_helper.hashes[].filename` | Contains the name of the file which is identified by the hash values. | WINWORD.EXE, msotadddin.dll, sudoers.so |
 | `product_tree.branches[].product.product_identification_helper.purl` | The package URL (purl) attribute refers to a method for reliably identifying and locating software packages external to this specification. | |
+| `product_tree.branches[].product.product_identification_helper.sbom_urls` | Contains a list of URLs where SBOMs for this product can be retrieved.| |
+| `product_tree.branches[].product.product_identification_helper.sbom_urls[]` | Contains a URL of one SBOM for this product. | |
 | `product_tree.branches[].product.product_identification_helper.serial_numbers` | Contains a list of parts, or full serial numbers.| |
 | `product_tree.branches[].product.product_identification_helper.serial_numbers[]` | Contains a part, or a full serial number of the component to identify. | |
+| `product_tree.branches[].product.product_identification_helper.skus` | Contains a list of parts, or full stock keeping units.| |
+| `product_tree.branches[].product.product_identification_helper.skus[]` | Contains a part, or a full stock keeping unit (SKU) which is used in the ordering process to identify the component. | |
 | `product_tree.branches[].product.product_identification_helper.x_generic_uris` | Contains a list of identifiers which are either vendor-specific or derived from a standard not yet supported.| |
 | `product_tree.branches[].product.product_identification_helper.x_generic_uris[]` | Provides a generic extension point for any identifier which is either vendor-specific or derived from a standard not yet supported. | |
 | `product_tree.branches[].product.product_identification_helper.x_generic_uris[].namespace` | Refers to a URL which provides the name and knowledge about the specification used or is the namespace in which these values are valid. | |
@@ -213,8 +225,12 @@ This is the full list of document properties. It reflects the structure as defin
 | `product_tree.full_product_names[].product_identification_helper.hashes[].file_hashes[].value` | Contains the cryptographic hash value in hexadecimal representation. | 4775203615d9534a8bfca96a93dc8b461a489f69124a130d786b42204f3341cc, 9ea4c8200113d49d26505da0e02e2f49055dc078d1ad7a419b32e291c7afebbb84badfbd46dec42883bea0b2a1fa697c, 37df33cb7464da5c7f077f4d56a32bc84987ec1d85b234537c1c1a4d4fc8d09dc29e2e762cb5203677bf849a2855a0283710f1f5fe1d6ce8d5ac85c645d0fcb3 |
 | `product_tree.full_product_names[].product_identification_helper.hashes[].filename` | Contains the name of the file which is identified by the hash values. | WINWORD.EXE, msotadddin.dll, sudoers.so |
 | `product_tree.full_product_names[].product_identification_helper.purl` | The package URL (purl) attribute refers to a method for reliably identifying and locating software packages external to this specification. | |
+| `product_tree.full_product_names[].product_identification_helper.sbom_urls` | Contains a list of URLs where SBOMs for this product can be retrieved.| |
+| `product_tree.full_product_names[].product_identification_helper.sbom_urls[]` | Contains a URL of one SBOM for this product. | |
 | `product_tree.full_product_names[].product_identification_helper.serial_numbers` | Contains a list of parts, or full serial numbers.| |
 | `product_tree.full_product_names[].product_identification_helper.serial_numbers[]` | Contains a part, or a full serial number of the component to identify. | |
+| `product_tree.full_product_names[].product_identification_helper.skus` | Contains a list of parts, or full stock keeping units.| |
+| `product_tree.full_product_names[].product_identification_helper.skus[]` | Contains a part, or a full stock keeping unit (SKU) which is used in the ordering process to identify the component. | |
 | `product_tree.full_product_names[].product_identification_helper.x_generic_uris` | Contains a list of identifiers which are either vendor-specific or derived from a standard not yet supported.| |
 | `product_tree.full_product_names[].product_identification_helper.x_generic_uris[]` | Provides a generic extension point for any identifier which is either vendor-specific or derived from a standard not yet supported. | |
 | `product_tree.full_product_names[].product_identification_helper.x_generic_uris[].namespace` | Refers to a URL which provides the name and knowledge about the specification used or is the namespace in which these values are valid. | |
@@ -241,8 +257,12 @@ This is the full list of document properties. It reflects the structure as defin
 | `product_tree.relationships[].full_product_name.product_identification_helper.hashes[].file_hashes[].value` | Contains the cryptographic hash value in hexadecimal representation. | 4775203615d9534a8bfca96a93dc8b461a489f69124a130d786b42204f3341cc, 9ea4c8200113d49d26505da0e02e2f49055dc078d1ad7a419b32e291c7afebbb84badfbd46dec42883bea0b2a1fa697c, 37df33cb7464da5c7f077f4d56a32bc84987ec1d85b234537c1c1a4d4fc8d09dc29e2e762cb5203677bf849a2855a0283710f1f5fe1d6ce8d5ac85c645d0fcb3 |
 | `product_tree.relationships[].full_product_name.product_identification_helper.hashes[].filename` | Contains the name of the file which is identified by the hash values. | WINWORD.EXE, msotadddin.dll, sudoers.so |
 | `product_tree.relationships[].full_product_name.product_identification_helper.purl` | The package URL (purl) attribute refers to a method for reliably identifying and locating software packages external to this specification. | |
+| `product_tree.relationships[].full_product_name.product_identification_helper.sbom_urls` | Contains a list of URLs where SBOMs for this product can be retrieved.| |
+| `product_tree.relationships[].full_product_name.product_identification_helper.sbom_urls[]` | Contains a URL of one SBOM for this product. | |
 | `product_tree.relationships[].full_product_name.product_identification_helper.serial_numbers` | Contains a list of parts, or full serial numbers.| |
 | `product_tree.relationships[].full_product_name.product_identification_helper.serial_numbers[]` | Contains a part, or a full serial number of the component to identify. | |
+| `product_tree.relationships[].full_product_name.product_identification_helper.skus` | Contains a list of parts, or full stock keeping units.| |
+| `product_tree.relationships[].full_product_name.product_identification_helper.skus[]` | Contains a part, or a full stock keeping unit (SKU) which is used in the ordering process to identify the component. | |
 | `product_tree.relationships[].full_product_name.product_identification_helper.x_generic_uris` | Contains a list of identifiers which are either vendor-specific or derived from a standard not yet supported.| |
 | `product_tree.relationships[].full_product_name.product_identification_helper.x_generic_uris[]` | Provides a generic extension point for any identifier which is either vendor-specific or derived from a standard not yet supported. | |
 | `product_tree.relationships[].full_product_name.product_identification_helper.x_generic_uris[].namespace` | Refers to a URL which provides the name and knowledge about the specification used or is the namespace in which these values are valid. | |
@@ -268,8 +288,9 @@ This is the full list of document properties. It reflects the structure as defin
 | `vulnerabilities[].id.system_name` | Indicates the name of the vulnerability tracking or numbering system. | Cisco Bug ID, GitHub Issue |
 | `vulnerabilities[].id.text` | Is unique label or tracking ID for the vulnerability (if such information exists). | CSCso66472, oasis-tcs/csaf#210 |
 | `vulnerabilities[].involvements` | Contains a list of involvements.| |
-| `vulnerabilities[].involvements[]` | Is a container, that allows the document producers to comment on their level of Involvement (or engagement) in the vulnerability identification, scoping, and remediation process. | |
-| `vulnerabilities[].involvements[].party` | Defines the type of the involved party. | |
+| `vulnerabilities[].involvements[]` | Is a container, that allows the document producers to comment on the level of involvement (or engagement) of themselves or third parties in the vulnerability identification, scoping, and remediation process. | |
+| `vulnerabilities[].involvements[].date` | Holds the date and time of the involvement entry. | |
+| `vulnerabilities[].involvements[].party` | Defines the category of the involved party. | |
 | `vulnerabilities[].involvements[].status` | Defines contact status of the involved party. | |
 | `vulnerabilities[].involvements[].summary` | Contains additional context regarding what is going on. | |
 | `vulnerabilities[].notes` | Contains notes which are specific to the current context.| |

--- a/app/lib/SecvisogramPage/View/FormEditorTab/Document/Tracking.js
+++ b/app/lib/SecvisogramPage/View/FormEditorTab/Document/Tracking.js
@@ -59,7 +59,7 @@ export default React.memo(
               {...trackingProps('generator')}
               label="Document generator"
               description="Is a container to hold all elements related to the generation of the document. These items will reference when the document was actually created, including the date it was generated and the entity that generated it."
-              defaultValue={() => ({ engine: '' })}
+              defaultValue={() => ({ engine: {} })}
               deletable={false}
             >
               {(generatorProps) => (
@@ -70,13 +70,32 @@ export default React.memo(
                     description="This SHOULD be the current date that the document was generated. Because documents are often generated internally by a document producer and exist for a nonzero amount of time before being released, this field MAY be different from the Initial Release Date and Current Release Date."
                     readOnly
                   />
-                  <TextAttribute
+                  <ObjectContainer
                     {...generatorProps('engine')}
                     label="Engine of document generation"
-                    description="This string SHOULD represent the name of the engine that generated the CSAF document, and MAY additionally refer to its version."
-                    placeholder="TVCE"
-                    readOnly
-                  />
+                    description="Contains information about the engine that generated the CSAF document."
+                    defaultValue={() => ({ name: '' })}
+                    deletable={false}
+                  >
+                    {(engineProps) => (
+                      <>
+                        <TextAttribute
+                          {...engineProps('name')}
+                          label="Engine name"
+                          description="Represents the name of the engine that generated the CSAF document."
+                          placeholder="Secvisogram"
+                          readOnly
+                        />
+                        <TextAttribute
+                          {...engineProps('version')}
+                          label="Engine version"
+                          description="Contains the version of the engine that generated the CSAF document."
+                          placeholder="0.6.0"
+                          readOnly
+                        />
+                      </>
+                    )}
+                  </ObjectContainer>
                 </>
               )}
             </ObjectContainer>

--- a/app/lib/SecvisogramPage/View/FormEditorTab/Vulnerabilities.js
+++ b/app/lib/SecvisogramPage/View/FormEditorTab/Vulnerabilities.js
@@ -128,15 +128,21 @@ const Vulnerability = React.memo(
                 <ObjectContainer
                   {...involvementItemProps}
                   label="Involvement"
-                  description="Is a container, that allows the document producers to comment on their level of Involvement (or engagement) in the vulnerability identification, scoping, and remediation process."
+                  description="Is a container, that allows the document producers to comment on the level of involvement (or engagement) of themselves or third parties in the vulnerability identification, scoping, and remediation process."
                   defaultValue={() => ({})}
                 >
                   {(involvementProps) => (
                     <>
+                      <DateAttribute
+                        {...involvementProps('date')}
+                        label="Date of involvement"
+                        description="Holds the date and time of the involvement entry."
+                        deletable
+                      />
                       <EnumAttribute
                         {...involvementProps('party')}
-                        label="Party type"
-                        description="Defines the type of the involved party."
+                        label="Party category"
+                        description="Defines the category of the involved party."
                         options={[
                           'coordinator',
                           'discoverer',

--- a/app/lib/SecvisogramPage/View/FormEditorTab/shared/definitions/FullProductName/ProductIdentificationHelper.js
+++ b/app/lib/SecvisogramPage/View/FormEditorTab/shared/definitions/FullProductName/ProductIdentificationHelper.js
@@ -114,6 +114,21 @@ export default function ProductIdentificationHelper({
             deletable
           />
           <ArrayContainer
+            {...productIdentificationHelperProps('sbom_urls')}
+            label="List of SBOM URLs"
+            description="Contains a list of URLs where SBOMs for this product can be retrieved."
+            defaultItemValue={() => ''}
+          >
+            {(sbomUrlsItemProps) => (
+              <TextAttribute
+                {...sbomUrlsItemProps}
+                label="SBOM URL"
+                description="Contains a URL of one SBOM for this product."
+                deletable
+              />
+            )}
+          </ArrayContainer>
+          <ArrayContainer
             {...productIdentificationHelperProps('serial_numbers')}
             label="List of serial numbers"
             description="Contains a list of parts, or full serial numbers."
@@ -124,6 +139,21 @@ export default function ProductIdentificationHelper({
                 {...serialNumbersItemProps}
                 label="Serial number"
                 description="Contains a part, or a full serial number of the component to identify."
+                deletable
+              />
+            )}
+          </ArrayContainer>
+          <ArrayContainer
+            {...productIdentificationHelperProps('skus')}
+            label="List of stock keeping units"
+            description="Contains a list of parts, or full stock keeping units."
+            defaultItemValue={() => ''}
+          >
+            {(skusItemProps) => (
+              <TextAttribute
+                {...skusItemProps}
+                label="Stock keeping unit"
+                description="Contains a part, or a full stock keeping unit (SKU) which is used in the ordering process to identify the component."
                 deletable
               />
             )}

--- a/app/lib/SecvisogramPage/View/Reducer.js
+++ b/app/lib/SecvisogramPage/View/Reducer.js
@@ -2,6 +2,15 @@ import update from 'immutability-helper'
 import { parse } from 'json-pointer'
 import { compose, set } from 'lodash/fp'
 
+/* eslint-disable */
+const secvisogramVersion =
+  typeof SECVISOGRAM_VERSION !== 'undefined'
+    ? SECVISOGRAM_VERSION.startsWith('v')
+      ? SECVISOGRAM_VERSION.substr(1)
+      : SECVISOGRAM_VERSION
+    : 'unidentified version'
+/* eslint-enable */
+
 /** @typedef {unknown} Doc */
 
 /**
@@ -38,8 +47,9 @@ export default function Reducer(state, action) {
       }
     case 'CHANGE_FORM_DOC': {
       const setGeneratorFields = compose(
-        set('document.tracking.generator.date', action.timestamp.toISOString()),
-        set('document.tracking.generator.engine', 'Secvisogram')
+        set('document.tracking.generator.engine.name', 'Secvisogram'),
+        set('document.tracking.generator.engine.version', secvisogramVersion),
+        set('document.tracking.generator.date', action.timestamp.toISOString())
       )
       return {
         ...state,

--- a/app/lib/shared/Core.js
+++ b/app/lib/shared/Core.js
@@ -10,10 +10,20 @@ import doc_max from './Core/doc-max.json'
 import doc_min from './Core/doc-min.json'
 import { DocumentEntity } from './Core/entities'
 
+/* eslint-disable */
+const secvisogramVersion =
+  typeof SECVISOGRAM_VERSION !== 'undefined'
+    ? SECVISOGRAM_VERSION.startsWith('v')
+      ? SECVISOGRAM_VERSION.substr(1)
+      : SECVISOGRAM_VERSION
+    : 'unidentified version'
+/* eslint-enable */
+
 const setGeneratorFields = (/** @type {Date} */ date) =>
   compose(
-    set('document.tracking.generator.date', date.toISOString()),
-    set('document.tracking.generator.engine', 'Secvisogram')
+    set('document.tracking.generator.engine.name', 'Secvisogram'),
+    set('document.tracking.generator.engine.version', secvisogramVersion),
+    set('document.tracking.generator.date', date.toISOString())
   )
 
 /**

--- a/app/lib/shared/Core/csaf_2.0.json
+++ b/app/lib/shared/Core/csaf_2.0.json
@@ -218,6 +218,18 @@
               "pattern": "^pkg:",
               "minLength": 4
             },
+            "sbom_urls": {
+              "title": "List of SBOM URLs",
+              "description": "Contains a list of URLs where SBOMs for this product can be retrieved.",
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "title": "SBOM URL",
+                "description": "Contains a URL of one SBOM for this product.",
+                "type": "string",
+                "format": "uri"
+              }
+            },
             "serial_numbers": {
               "$comment": "TODO: Add remark in prose that this should only be used if a certain range of serial numbers with a software version is affected, or the serial numbers change during update.",
               "title": "List of serial numbers",
@@ -227,6 +239,18 @@
               "items": {
                 "title": "Serial number",
                 "description": "Contains a part, or a full serial number of the component to identify.",
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "skus": {
+              "title": "List of stock keeping units",
+              "description": "Contains a list of parts, or full stock keeping units.",
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "title": "Stock keeping unit",
+                "description": "Contains a part, or a full stock keeping unit (SKU) which is used in the ordering process to identify the component.",
                 "type": "string",
                 "minLength": 1
               }
@@ -625,14 +649,29 @@
                 },
                 "engine": {
                   "title": "Engine of document generation",
-                  "description": "This string SHOULD represent the name of the engine that generated the CSAF document, and MAY additionally refer to its version.",
-                  "type": "string",
-                  "minLength": 1,
-                  "examples": [
-                    "TVCE",
-                    "Red Hat rhsa-to-cvrf 2.1",
-                    "CMPFA Core Converter CVRF->CSAF Version 0.6"
-                  ]
+                  "description": "Contains information about the engine that generated the CSAF document.",
+                  "type": "object",
+                  "required": ["name"],
+                  "properties": {
+                    "name": {
+                      "title": "Engine name",
+                      "description": "Represents the name of the engine that generated the CSAF document.",
+                      "type": "string",
+                      "minLength": 1,
+                      "examples": [
+                        "Red Hat rhsa-to-cvrf",
+                        "Secvisogram",
+                        "TVCE"
+                      ]
+                    },
+                    "version": {
+                      "title": "Engine version",
+                      "description": "Contains the version of the engine that generated the CSAF document.",
+                      "type": "string",
+                      "minLength": 1,
+                      "examples": ["0.6.0", "2", "1.0.0-beta+exp.sha.a1c44f85"]
+                    }
+                  }
                 }
               }
             },
@@ -872,15 +911,22 @@
             "description": "Contains a list of involvements.",
             "type": "array",
             "minItems": 1,
+            "uniqueItems": true,
             "items": {
               "title": "Involvement",
-              "description": "Is a container, that allows the document producers to comment on their level of Involvement (or engagement) in the vulnerability identification, scoping, and remediation process.",
+              "description": "Is a container, that allows the document producers to comment on the level of involvement (or engagement) of themselves or third parties in the vulnerability identification, scoping, and remediation process.",
               "type": "object",
               "required": ["party", "status"],
               "properties": {
+                "date": {
+                  "title": "Date of involvement",
+                  "description": "Holds the date and time of the involvement entry.",
+                  "type": "string",
+                  "format": "date-time"
+                },
                 "party": {
-                  "title": "Party type",
-                  "description": "Defines the type of the involved party.",
+                  "title": "Party category",
+                  "description": "Defines the category of the involved party.",
                   "type": "string",
                   "enum": [
                     "coordinator",

--- a/app/lib/shared/Core/csaf_2.0_strict.json
+++ b/app/lib/shared/Core/csaf_2.0_strict.json
@@ -217,6 +217,18 @@
               "title": "package URL representation",
               "type": "string"
             },
+            "sbom_urls": {
+              "description": "Contains a list of URLs where SBOMs for this product can be retrieved.",
+              "items": {
+                "description": "Contains a URL of one SBOM for this product.",
+                "format": "uri",
+                "title": "SBOM URL",
+                "type": "string"
+              },
+              "minItems": 1,
+              "title": "List of SBOM URLs",
+              "type": "array"
+            },
             "serial_numbers": {
               "$comment": "TODO: Add remark in prose that this should only be used if a certain range of serial numbers with a software version is affected, or the serial numbers change during update.",
               "description": "Contains a list of parts, or full serial numbers.",
@@ -228,6 +240,18 @@
               },
               "minItems": 1,
               "title": "List of serial numbers",
+              "type": "array"
+            },
+            "skus": {
+              "description": "Contains a list of parts, or full stock keeping units.",
+              "items": {
+                "description": "Contains a part, or a full stock keeping unit (SKU) which is used in the ordering process to identify the component.",
+                "minLength": 1,
+                "title": "Stock keeping unit",
+                "type": "string"
+              },
+              "minItems": 1,
+              "title": "List of stock keeping units",
               "type": "array"
             },
             "x_generic_uris": {
@@ -616,15 +640,31 @@
                   "type": "string"
                 },
                 "engine": {
-                  "description": "This string SHOULD represent the name of the engine that generated the CSAF document, and MAY additionally refer to its version.",
-                  "examples": [
-                    "TVCE",
-                    "Red Hat rhsa-to-cvrf 2.1",
-                    "CMPFA Core Converter CVRF->CSAF Version 0.6"
-                  ],
-                  "minLength": 1,
+                  "additionalProperties": false,
+                  "description": "Contains information about the engine that generated the CSAF document.",
+                  "properties": {
+                    "name": {
+                      "description": "Represents the name of the engine that generated the CSAF document.",
+                      "examples": [
+                        "Red Hat rhsa-to-cvrf",
+                        "Secvisogram",
+                        "TVCE"
+                      ],
+                      "minLength": 1,
+                      "title": "Engine name",
+                      "type": "string"
+                    },
+                    "version": {
+                      "description": "Contains the version of the engine that generated the CSAF document.",
+                      "examples": ["0.6.0", "2", "1.0.0-beta+exp.sha.a1c44f85"],
+                      "minLength": 1,
+                      "title": "Engine version",
+                      "type": "string"
+                    }
+                  },
+                  "required": ["name"],
                   "title": "Engine of document generation",
-                  "type": "string"
+                  "type": "object"
                 }
               },
               "required": ["engine"],
@@ -887,10 +927,16 @@
             "description": "Contains a list of involvements.",
             "items": {
               "additionalProperties": false,
-              "description": "Is a container, that allows the document producers to comment on their level of Involvement (or engagement) in the vulnerability identification, scoping, and remediation process.",
+              "description": "Is a container, that allows the document producers to comment on the level of involvement (or engagement) of themselves or third parties in the vulnerability identification, scoping, and remediation process.",
               "properties": {
+                "date": {
+                  "description": "Holds the date and time of the involvement entry.",
+                  "format": "date-time",
+                  "title": "Date of involvement",
+                  "type": "string"
+                },
                 "party": {
-                  "description": "Defines the type of the involved party.",
+                  "description": "Defines the category of the involved party.",
                   "enum": [
                     "coordinator",
                     "discoverer",
@@ -898,7 +944,7 @@
                     "user",
                     "vendor"
                   ],
-                  "title": "Party type",
+                  "title": "Party category",
                   "type": "string"
                 },
                 "status": {
@@ -927,7 +973,8 @@
             },
             "minItems": 1,
             "title": "List of involvements",
-            "type": "array"
+            "type": "array",
+            "uniqueItems": true
           },
           "notes": {
             "$ref": "#/definitions/notes_t"

--- a/app/lib/shared/Core/doc-max.json
+++ b/app/lib/shared/Core/doc-max.json
@@ -51,7 +51,10 @@
       "current_release_date": "",
       "generator": {
         "date": "",
-        "engine": ""
+        "engine": {
+          "name": "",
+          "version": ""
+        }
       },
       "id": "",
       "initial_release_date": "",
@@ -89,7 +92,9 @@
               }
             ],
             "purl": "",
+            "sbom_urls": [""],
             "serial_numbers": [""],
+            "skus": [""],
             "x_generic_uris": [
               {
                 "namespace": "",
@@ -118,7 +123,9 @@
             }
           ],
           "purl": "",
+          "sbom_urls": [""],
           "serial_numbers": [""],
+          "skus": [""],
           "x_generic_uris": [
             {
               "namespace": "",
@@ -155,7 +162,9 @@
               }
             ],
             "purl": "",
+            "sbom_urls": [""],
             "serial_numbers": [""],
+            "skus": [""],
             "x_generic_uris": [
               {
                 "namespace": "",
@@ -191,6 +200,7 @@
       },
       "involvements": [
         {
+          "date": "",
           "party": "",
           "status": "",
           "summary": ""

--- a/app/seeds/documents/valid-1.json
+++ b/app/seeds/documents/valid-1.json
@@ -53,7 +53,9 @@
       "initial_release_date": "2018-03-28T16:00:00Z",
       "current_release_date": "2018-04-17T15:08:41Z",
       "generator": {
-        "engine": "TVCE"
+        "engine": {
+          "name": "TVCE"
+        }
       }
     },
     "notes": [
@@ -351,7 +353,7 @@
               },
               {
                 "name": "15.0EY",
-                "category": "product_version",                
+                "category": "product_version",
                 "branches": [
                   {
                     "name": "15.0(1)EY",
@@ -2760,7 +2762,7 @@
           "CVRFPID-236834"
         ]
       },
-      "scores": [ 
+      "scores": [
         {
           "products": [
             "CVRFPID-103559",
@@ -3023,13 +3025,12 @@
             "CVRFPID-233155",
             "CVRFPID-236834"
           ],
-          "cvss_v3": 
-            {
-              "version": "3.0",
-              "baseScore": 9.8,
-              "baseSeverity": "CRITICAL",
-              "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
-            }
+          "cvss_v3": {
+            "version": "3.0",
+            "baseScore": 9.8,
+            "baseSeverity": "CRITICAL",
+            "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+          }
         }
       ],
       "remediations": [

--- a/app/seeds/documents/valid-2.json
+++ b/app/seeds/documents/valid-2.json
@@ -23,8 +23,11 @@
       "initial_release_date": "2018-03-28T13:49:00Z",
       "current_release_date": "2018-03-28T13:49:00Z",
       "generator": {
-        "engine": "Red Hat rhsa-to-cvrf 2.1",
-        "date": "2018-04-11T19:24:01Z"
+        "date": "2018-04-11T19:24:01Z",
+        "engine": {
+          "name": "Red Hat rhsa-to-cvrf",
+          "version": "2.1"
+        }
       }
     },
     "notes": [

--- a/app/tests/SecvisogramPage.js
+++ b/app/tests/SecvisogramPage.js
@@ -50,8 +50,11 @@ suite('SecvisogramPage', () => {
           timestamp.toISOString()
         )
         expect(
-          state.formValues.doc.document.tracking.generator.engine
+          state.formValues.doc.document.tracking.generator.engine.name
         ).to.equal('Secvisogram')
+        expect(
+          state.formValues.doc.document.tracking.generator.engine.version
+        ).to.equal('unidentified version')
       })
 
       test('The form can be reset', () => {


### PR DESCRIPTION
- resolves secvisogram/secvisogram#119
- implement current version of schema (without adding tests)
- replace https with http in $schema to be compatible with ajv (and the [specification](https://json-schema.org/draft-07/json-schema-validation.html#rfc.section.5))