### PR TITLE
Publisher namespace

### DIFF
--- a/PREVIEW-TEMPLATING.md
+++ b/PREVIEW-TEMPLATING.md
@@ -114,7 +114,7 @@ This is the full list of document properties. It reflects the structure as defin
 | `document.publisher.contact_details` | Information on how to contact the publisher, possibly including details such as web sites, email addresses, phone numbers, and postal mail addresses. | Example Company can be reached at contact_us@example.com, or via our website at https://www.example.com/contact. |
 | `document.publisher.issuing_authority` | Provides information about the authority of the issuing party to release the document, in particular, the party's constituency and responsibilities or other obligations. | |
 | `document.publisher.name` | Contains the name of the issuing party. | BSI, Cisco PSIRT, Siemens ProductCERT |
-| `document.publisher.vendor_id` | Vendor ID is a unique identifier (OID) that a vendor uses as issued by FIRST under the auspices of IETF. | |
+| `document.publisher.namespace` | Contains a URL which is under control of the issuing party and can be used as a globally unique identifier for that issuing party. | https://www.example.com, https://csaf.io |
 | `document.references` | Holds a list of references.| |
 | `document.references[]` | Holds any reference to conferences, papers, advisories, and other resources that are related and considered related to either a surrounding part of or the entire document and to be of value to the document consumer. | |
 | `document.references[].category` | Indicates whether the reference points to the same document or vulnerability in focus (depending on scope) or to an external resource. | |

--- a/app/lib/SecvisogramPage/View/FormEditorTab.js
+++ b/app/lib/SecvisogramPage/View/FormEditorTab.js
@@ -285,6 +285,7 @@ function Doc(props) {
           publisher: {
             category: '',
             name: '',
+            namespace: '',
           },
           title: '',
           tracking: {

--- a/app/lib/SecvisogramPage/View/FormEditorTab/Document/Publisher.js
+++ b/app/lib/SecvisogramPage/View/FormEditorTab/Document/Publisher.js
@@ -60,10 +60,10 @@ export default React.memo(
               placeholder="Example PSIRT"
             />
             <TextAttribute
-              {...publisherProps('vendor_id')}
-              label="Vendor releasing the document"
-              description="Vendor ID is a unique identifier (OID) that a vendor uses as issued by FIRST under the auspices of IETF."
-              deletable
+              {...publisherProps('namespace')}
+              label="Namespace of publisher"
+              description="Contains a URL which is under control of the issuing party and can be used as a globally unique identifier for that issuing party."
+              placeholder="https://www.example.com"
             />
           </>
         )}

--- a/app/lib/SecvisogramPage/View/shared/HTMLTemplate/Template.html
+++ b/app/lib/SecvisogramPage/View/shared/HTMLTemplate/Template.html
@@ -300,6 +300,7 @@
 
   {{#document.publisher}}
     <h2>{{name}}</h2>
+    <p>Namespace: {{namespace}}</p>
     <p>{{contact_details}}</p>
     <p>{{issuing_authority}}</p>
   {{/document.publisher}}

--- a/app/lib/shared/Core/csaf_2.0.json
+++ b/app/lib/shared/Core/csaf_2.0.json
@@ -539,7 +539,7 @@
           "title": "Publisher",
           "description": "Provides information about the publisher of the document.",
           "type": "object",
-          "required": ["category", "name"],
+          "required": ["category", "name", "namespace"],
           "properties": {
             "category": {
               "title": "Category of publisher",
@@ -576,11 +576,12 @@
               "minLength": 1,
               "examples": ["BSI", "Cisco PSIRT", "Siemens ProductCERT"]
             },
-            "vendor_id": {
-              "title": "Vendor releasing the document",
-              "description": "Vendor ID is a unique identifier (OID) that a vendor uses as issued by FIRST under the auspices of IETF.",
+            "namespace": {
+              "title": "Namespace of publisher",
+              "description": "Contains a URL which is under control of the issuing party and can be used as a globally unique identifier for that issuing party.",
               "type": "string",
-              "minLength": 1
+              "format": "uri",
+              "examples": ["https://www.example.com", "https://csaf.io"]
             }
           }
         },

--- a/app/lib/shared/Core/csaf_2.0_strict.json
+++ b/app/lib/shared/Core/csaf_2.0_strict.json
@@ -576,14 +576,15 @@
               "title": "Name of publisher",
               "type": "string"
             },
-            "vendor_id": {
-              "description": "Vendor ID is a unique identifier (OID) that a vendor uses as issued by FIRST under the auspices of IETF.",
-              "minLength": 1,
-              "title": "Vendor releasing the document",
+            "namespace": {
+              "description": "Contains a URL which is under control of the issuing party and can be used as a globally unique identifier for that issuing party.",
+              "examples": ["https://www.example.com", "https://csaf.io"],
+              "format": "uri",
+              "title": "Namespace of publisher",
               "type": "string"
             }
           },
-          "required": ["category", "name"],
+          "required": ["category", "name", "namespace"],
           "title": "Publisher",
           "type": "object"
         },

--- a/app/lib/shared/Core/doc-max.json
+++ b/app/lib/shared/Core/doc-max.json
@@ -35,7 +35,7 @@
       "contact_details": "",
       "issuing_authority": "",
       "name": "",
-      "vendor_id": ""
+      "namespace": ""
     },
     "references": [
       {

--- a/app/lib/shared/Core/doc-min.json
+++ b/app/lib/shared/Core/doc-min.json
@@ -4,7 +4,8 @@
     "csaf_version": "2.0",
     "publisher": {
       "category": "",
-      "name": ""
+      "name": "",
+      "namespace": ""
     },
     "title": "",
     "tracking": {

--- a/app/seeds/documents/valid-1.json
+++ b/app/seeds/documents/valid-1.json
@@ -4,10 +4,11 @@
     "category": "Cisco Security Advisory",
     "csaf_version": "2.0",
     "publisher": {
+      "category": "vendor",
       "contact_details": "Emergency Support:\n+1 877 228 7302 (toll-free within North America)\n+1 408 525 6532 (International direct-dial)\nNon-emergency Support:\nEmail: psirt@cisco.com\nSupport requests that are received via e-mail are typically acknowledged within 48 hours.",
       "issuing_authority": "Cisco product security incident response is the responsibility of the Cisco Product Security Incident Response Team (PSIRT). The Cisco PSIRT is a dedicated, global team that manages the receipt, investigation, and public reporting of security vulnerability information that is related to Cisco products and networks. The on-call Cisco PSIRT works 24x7 with Cisco customers, independent security researchers, consultants, industry organizations, and other vendors to identify possible security issues with Cisco products and networks.\nMore information can be found in Cisco Security Vulnerability Policy available at http://www.cisco.com/web/about/security/psirt/security_vulnerability_policy.html",
       "name": "Cisco PSIRT",
-      "category": "vendor"
+      "namespace": "https://www.cisco.com"
     },
     "tracking": {
       "id": "cisco-sa-20180328-smi2",
@@ -353,7 +354,7 @@
               },
               {
                 "name": "15.0EY",
-                "category": "product_version",
+                "category": "product_version",                
                 "branches": [
                   {
                     "name": "15.0(1)EY",
@@ -2762,7 +2763,7 @@
           "CVRFPID-236834"
         ]
       },
-      "scores": [
+      "scores": [ 
         {
           "products": [
             "CVRFPID-103559",
@@ -3025,12 +3026,13 @@
             "CVRFPID-233155",
             "CVRFPID-236834"
           ],
-          "cvss_v3": {
-            "version": "3.0",
-            "baseScore": 9.8,
-            "baseSeverity": "CRITICAL",
-            "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
-          }
+          "cvss_v3": 
+            {
+              "version": "3.0",
+              "baseScore": 9.8,
+              "baseSeverity": "CRITICAL",
+              "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+            }
         }
       ],
       "remediations": [

--- a/app/seeds/documents/valid-2.json
+++ b/app/seeds/documents/valid-2.json
@@ -5,9 +5,10 @@
     "category": "Security Advisory",
     "csaf_version": "2.0",
     "publisher": {
+      "category": "vendor",
       "contact_details": "secalert@redhat.com",
       "name": "Red Hat Product Security",
-      "category": "vendor"
+      "namespace": "https://www.redhat.com"
     },
     "tracking": {
       "id": "RHBA-2018:0489",
@@ -9110,7 +9111,9 @@
       ],
       "acknowledgments": [
         {
-          "names": ["Ben Parees"],
+          "names": [
+            "Ben Parees"
+          ],
           "organization": "Red Hat",
           "summary": "This issue was discovered by Ben Parees (Red Hat)."
         }
@@ -9582,7 +9585,9 @@
       ],
       "acknowledgments": [
         {
-          "names": ["Jessica Forrester"],
+          "names": [
+            "Jessica Forrester"
+          ],
           "organization": "Red Hat",
           "summary": "This issue was discovered by Jessica Forrester (Red Hat)."
         }

--- a/app/tests/shared/CoreFixture.js
+++ b/app/tests/shared/CoreFixture.js
@@ -10,6 +10,7 @@ const MINIMAL_DOC = {
     publisher: {
       category: 'other',
       name: 'Secvisogram Automated Tester',
+      namespace: 'https://github.com/secvisogram/secvisogram',
     },
     tracking: {
       current_release_date: '2021-01-14T00:00:00.000Z',
@@ -62,6 +63,7 @@ export default function createCoreFixture() {
             publisher: {
               category: 'other',
               name: 'Secvisogram Automated Tester',
+              namespace: 'https://github.com/secvisogram/secvisogram',
             },
             tracking: {
               current_release_date: '2021-01-14T00:00:00.000Z',
@@ -172,6 +174,7 @@ export default function createCoreFixture() {
             publisher: {
               category: 'other',
               name: 'Secvisogram Automated Tester',
+              namespace: 'https://github.com/secvisogram/secvisogram',
             },
             tracking: {
               current_release_date: '2021-01-14T00:00:00.000Z',
@@ -200,6 +203,7 @@ export default function createCoreFixture() {
             publisher: {
               category: 'other',
               name: 'Secvisogram Automated Tester',
+              namespace: 'https://github.com/secvisogram/secvisogram',
             },
             tracking: {
               current_release_date: '2021-01-14T00:00:00.000Z',


### PR DESCRIPTION
- resolves secvisogram/secvisogram#142
- implement current version of schema without profile support (without adding tests)
- replace https with http in $schema to be compatible with ajv (and the specification)