### PR TITLE
Mandatory tests - fix 6.1.16

### DIFF
--- a/app/lib/shared/Core/entities/DocumentEntity.js
+++ b/app/lib/shared/Core/entities/DocumentEntity.js
@@ -489,15 +489,20 @@ export default class DocumentEntity {
     if (
       hasTrackingRevisionHistory(doc) &&
       hasTrackingVersionField(doc) &&
+      hasTrackingStatusField(doc) &&
       doc.document.tracking.revision_history.length > 0
     ) {
+      const version =
+        doc.document.tracking.status == 'draft'
+          ? doc.document.tracking.version.split(/[+-]/)[0]
+          : doc.document.tracking.version.split('+')[0]
       if (
         doc.document.tracking.revision_history
           .slice()
           .sort(
             (a, z) => new Date(z.date).getTime() - new Date(a.date).getTime()
           )[0]
-          .number.split('+')[0] !== doc.document.tracking.version.split('+')[0]
+          .number.split('+')[0] !== version
       ) {
         isValid = false
         errors.push({
@@ -613,7 +618,7 @@ export default class DocumentEntity {
       mandatoryTest_6_1_24,
       mandatoryTest_6_1_25,
       mandatoryTest_6_1_26,
-      mandatoryTest_6_1_27_9
+      mandatoryTest_6_1_27_9,
     ]
     tests.forEach((test) => {
       const result = test(doc)

--- a/app/tests/shared/coreFixture.js
+++ b/app/tests/shared/coreFixture.js
@@ -947,6 +947,28 @@ export default {
       },
     },
 
+    {
+      valid: true,
+      content: {
+        ...MINIMAL_DOC,
+        document: {
+          ...MINIMAL_DOC.document,
+          tracking: {
+            ...MINIMAL_DOC.document.tracking,
+            revision_history: [
+              {
+                number: '1.0.0',
+                date: '2021-01-14T00:00:00.000Z',
+                summary: 'Initial version',
+              },
+            ],
+            status: 'draft',
+            version: '1.0.0-alpha+123',
+          },
+        },
+      },
+    },
+
     // Fails "6.1.7 Multiple Scores with same Version per Product"
     {
       valid: false,


### PR DESCRIPTION
- resolves secvisogram/secvisogram#190 (tracked standard change in 6.1.16 made in oasis-tcs/csaf#339)
- ignore pre-release part if document status is draft