### PR TITLE
Mandatory tests - fix 6.1.24

### DIFF
--- a/app/lib/shared/Core/entities/DocumentEntity/mandatoryTest_6_1_24.js
+++ b/app/lib/shared/Core/entities/DocumentEntity/mandatoryTest_6_1_24.js
@@ -15,18 +15,17 @@ export default function mandatoryTest_6_1_24(doc) {
       vulnerability.involvements.forEach((involvement, involvementIndex) => {
         if (
           typeof involvement.date === 'string' &&
-          typeof involvement.party === 'string' &&
-          typeof involvement.status === 'string'
+          typeof involvement.party === 'string'
         ) {
           const set = involvementMap.get(involvement.date) ?? new Set()
-          if (set.has(`${involvement.party}:${involvement.status}`)) {
+          if (set.has(`${involvement.party}`)) {
             isValid = false
             errors.push({
-              message: `party, status tuple was already used for the same date`,
+              message: `status for party was already given for the same date`,
               instancePath: `/vulnerabilities/${vulnerabilityIndex}/involvements/${involvementIndex}`,
             })
           }
-          set.add(`${involvement.party}:${involvement.status}`)
+          set.add(`${involvement.party}`)
           involvementMap.set(involvement.date, set)
         }
       })

--- a/app/tests/shared/coreFixture.js
+++ b/app/tests/shared/coreFixture.js
@@ -1405,6 +1405,31 @@ export default {
       },
     },
 
+    {
+      valid: false,
+      content: {
+        ...MINIMAL_DOC,
+        vulnerabilities: [
+          {
+            involvements: [
+              {
+                date: '2021-04-23T10:00:00.000Z',
+                party: 'vendor',
+                status: 'completed',
+              },
+              {
+                date: '2021-04-23T10:00:00.000Z',
+                party: 'vendor',
+                status: 'in_progress',
+                summary:
+                  'The vendor has released a mitigation and is working to fully resolve the issue.',
+              },
+            ],
+          },
+        ],
+      },
+    },
+
     // Fails "6.1.25 Multiple Use of Same Hash Algorithm"
     {
       valid: false,


### PR DESCRIPTION
- resolves secvisogram/secvisogram#193 (tracked standard change in 6.1.24 made in oasis-tcs/csaf#351)
- remove status from the tuple as only one status can be defined for a party at a given time