### PR TITLE
Feat/add md merge script

### DIFF
--- a/docs/md_merge.py
+++ b/docs/md_merge.py
@@ -1,0 +1,357 @@
+import argparse
+import os
+import re
+import shutil
+from argparse import BooleanOptionalAction
+from collections import OrderedDict, defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+MD_HEADER_REGEX = (
+    r"^"            # start of line
+    r"(\s{0,3})"    # Group 1: zero to three whitespaces, tabs etc (four and more spaces are no heading)
+    r"(#{1,6})"     # Group 2: one or up to 6 '#'
+    r"(\s{0,})"     # Group 3: zero or more whitespaces
+    r"([^#].*)"     # Group 4: one or more chars but not starting with another #         
+    r"$"            # end of line
+)
+
+MD_IMAGE_REGEX = (
+    r"^"            # start of line
+    r"(.*)"         # Group 1: optional preceding text
+    r"(!\[)"        # Group 2: "!["
+    r"(.*)"         # Group 3: optional alt text
+    r"(\]\()"       # Group 4: "]("
+    r"([^\s]*)"     # Group 5: image link
+    r"\s*(.*)"      # Group 6: nothing or a whitespace and the optional image title, including quotes
+    r"(\))"         # Group 7: closing parenthesis
+    r'(.*)'         # Group 8: optional subsequent text
+    r"$"            # end of line
+)
+
+MD_LINK_REGEX = (
+    r"^"                        # start of line
+    r"(.*)"                     # Group 1: optional preceding text
+    r"(\[)"                     # Group 2: "["
+    r"(.*)"                     # Group 3: link text
+    r"(\]\()"                   # Group 4: "]("
+    r"([a-zA-Z0-9.:\/#\-_]+)"   # Group 5: link
+    r"(\))"                     # Group 6: closing parenthesis
+    r"(.*)"                     # Group 7: optional subsequent text
+    r"$"                        # end of line
+)
+
+
+@dataclass
+class HeaderLine:
+    depth: int
+    text: str
+
+    def to_text(self, new_depth: Optional[int] = None):
+        hashes = "#" * new_depth if new_depth is not None else "#" * self.depth
+        return f"{hashes} {self.text}"
+
+
+@dataclass
+class LinkLine:
+    link: str
+    link_text: str = ""
+    preceding_text: str = ""
+    subsequent_text: str = ""
+
+    @property
+    def is_external(self):
+        return self.link.startswith("http")
+
+    def to_text(self):
+        raise NotImplementedError()
+
+
+@dataclass
+class ImageLine(LinkLine):
+    title_text: str = ""
+
+    def to_text(self):
+        title_part = f' "{self.title_text}"' if self.title_text else ""
+        return f'{self.preceding_text}![{self.link_text}]({self.link}{title_part}){self.subsequent_text}'
+
+
+@dataclass
+class TextLinkLine(LinkLine):
+
+    def to_text(self):
+        return f"{self.preceding_text}[{self.link_text}]({self.link}){self.subsequent_text}"
+
+    @property
+    def is_anchor_link(self):
+        return self.link.startswith("#")
+
+
+def parse_line(line: str):
+    header_search = re.search(MD_HEADER_REGEX, line, re.IGNORECASE)
+    if header_search:
+        return HeaderLine(depth=len(header_search.group(2)), text=header_search.group(4))
+    image_search = re.search(MD_IMAGE_REGEX, line, re.IGNORECASE)
+    if image_search:
+        return ImageLine(
+            link=image_search.group(5),
+            link_text=image_search.group(3),
+            title_text=image_search.group(6)[1:-1],
+            preceding_text=image_search.group(1),
+            subsequent_text=image_search.group(8)
+        )
+    link_search = re.search(MD_LINK_REGEX, line, re.IGNORECASE)
+    if link_search:
+        return TextLinkLine(
+            link=link_search.group(5),
+            link_text=link_search.group(3),
+            preceding_text=link_search.group(1),
+            subsequent_text=link_search.group(7)
+        )
+    return line
+
+
+def get_dir_content(dir_path: Path, language: str = "en", files_only=False):
+    """lists the contents of a directory and sorts it alphabetically
+    starting with files and then directories
+    if files_only is set to True, directories will be excluded
+
+    tries to fetch only markdown files with a language specific suffix
+
+    Example:
+
+        document-spec.en.md
+        document-usage.en.md
+        document
+        vulnerabilities-spec.en.md
+        vulnerabilities-usage.en.md
+        vulnerabilities
+
+    the results later on influence the ordering of content in a merged file
+    """
+
+    dirs = [p for p in os.listdir(dir_path) if os.path.isdir(dir_path / p)]
+    files = get_md_language_files(dir_path, language)
+
+    if files_only:
+        return sorted(files)
+
+    result = []
+    for d in sorted(dirs):
+        for f in sorted(files):
+            if f.startswith(d):
+                result.append(f)
+        result.append(d)
+    for f in sorted(files):
+        if f not in result:
+            result.append(f)
+
+    return result
+
+
+LANGUAGE_MD_FILE_NAME_PATTERN = "(.+)[.](.{2,3})[.]md"
+
+
+def get_md_language_files(dir_path: Path, language: str = "en"):
+    """tries to fetch all markdown files with a language specific suffix
+    assumes that files in English (suffix '.en.md') are all present
+    and uses these as fallback"""
+    lang_to_file_prefix = defaultdict(list)
+    for md_file in os.listdir(dir_path):
+        match = re.match(LANGUAGE_MD_FILE_NAME_PATTERN, md_file)
+        if match:
+            lang = match.group(2)
+            lang_to_file_prefix[lang].append(match.group(1))
+    result = []
+    for prefix in lang_to_file_prefix["en"]:
+        expected_file = prefix + f".{language}.md"
+        if prefix in lang_to_file_prefix[language]:
+            result.append(expected_file)
+        else:
+            print(f"missing file '{expected_file}', falling back to English version")
+            result.append(prefix + ".en.md")
+    return result
+
+
+LINK_COUNT = 1
+IMG_COUNT = 1
+PATH_TO_DEPTH_AND_CONTENT = OrderedDict()
+PATH_TO_LINK_ID = defaultdict(list)
+
+
+def parse_dir_recursive(
+        start_dir: Path,
+        current_dir: Path,
+        output_dir: Path,
+        language: str,
+        depth=1,
+        max_depth=-1,
+        paths_relative_to_input_dir=False
+):
+    global LINK_COUNT
+    global IMG_COUNT
+
+    files_only = max_depth == 0
+
+    dir_content = get_dir_content(current_dir, language, files_only=files_only)
+    for dc in dir_content:
+        path = current_dir / dc
+        if path.is_file():
+            file_lines = []
+            for line in path.read_text().splitlines():
+                parsed_line = parse_line(line)
+                if isinstance(parsed_line, ImageLine) and not parsed_line.is_external:
+                    new_image_name = f"md-merge-img-{IMG_COUNT}-" + Path(parsed_line.link).name
+                    new_image_path = output_dir / "images" / new_image_name
+                    shutil.copyfile(current_dir / parsed_line.link, new_image_path)
+                    parsed_line.link = str(new_image_path.relative_to(output_dir))
+                if isinstance(parsed_line, TextLinkLine) and not (parsed_line.is_external
+                                                                  or parsed_line.is_anchor_link):
+                    if paths_relative_to_input_dir:
+                        linked_path = start_dir / parsed_line.link
+                    else:
+                        linked_path = path.parent / parsed_line.link
+                    link_name = f"md-merge-link-{LINK_COUNT}"
+                    parsed_line.link = "#" + link_name
+                    PATH_TO_LINK_ID[linked_path].append(link_name)
+                    LINK_COUNT += 1
+                file_lines.append(parsed_line)
+            PATH_TO_DEPTH_AND_CONTENT[path] = (depth, file_lines)
+        elif path.is_dir():
+            parse_dir_recursive(start_dir, path, output_dir, language, depth + 1, max_depth - 1, paths_relative_to_input_dir)
+
+
+def main(args):
+
+    global LINK_COUNT
+    global IMG_COUNT
+    global PATH_TO_DEPTH_AND_CONTENT
+    global PATH_TO_LINK_ID
+
+    LINK_COUNT = 1
+    IMG_COUNT = 1
+    PATH_TO_DEPTH_AND_CONTENT = OrderedDict()
+    PATH_TO_LINK_ID = defaultdict(list)
+
+    input_dir = Path(args.input)
+    output_dir = Path(args.output)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "images").mkdir(exist_ok=True)
+
+    parse_dir_recursive(
+        input_dir,
+        input_dir,
+        output_dir,
+        args.language,
+        depth=args.depth,
+        max_depth=args.max_depth,
+        paths_relative_to_input_dir=args.paths_relative_to_input_dir
+    )
+
+    output_file_path = os.path.join(args.output, args.name)
+
+    with open(output_file_path, "w+", encoding="UTF-8") as output_file:
+
+        for file_path, (depth, content) in PATH_TO_DEPTH_AND_CONTENT.items():
+            for linked_path, link_names in PATH_TO_LINK_ID.items():
+                if not linked_path.exists():
+                    raise ValueError(f"Linked file '{str(linked_path)}' does not exist! (link in '{str(file_path)}')")
+                if file_path.samefile(linked_path):
+                    for link_name in link_names:
+                        link_anchor = f'<a name="{link_name}"></a>'
+                        output_file.write(link_anchor + "\n")
+
+            for line in content:
+                text = line
+                if isinstance(line, HeaderLine):
+                    text = line.to_text(new_depth=depth)
+                if isinstance(line, LinkLine):
+                    text = line.to_text()
+                output_file.write(text + "\n")
+            output_file.write("\n")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Merge multiple markdown files into one."
+    )
+    parser.add_argument(
+        "-i",
+        "--input",
+        dest="input",
+        default=".",
+        type=handle_input_path,
+        help="path to the input folder",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        dest="output",
+        default="./out/",
+        type=handle_output_path,
+        help="path to the output folder",
+    )
+    parser.add_argument(
+        "-n",
+        "--name",
+        dest="name",
+        default="output.md",
+        type=str,
+        help="name of the output document",
+    )
+    parser.add_argument(
+        "-l",
+        "--lang",
+        dest="language",
+        default="en",
+        type=str,
+        help="the language code used in the filenames (.<language>.md)",
+    )
+    parser.add_argument(
+        "-d",
+        "--depth",
+        dest="depth",
+        default=1,
+        type=int,
+        help="the initial depth of headers to consider, 1 will prepend a single '#' to header lines,"
+             " another '#' will be added whenever descending into a subdirectory"
+    )
+    parser.add_argument(
+        "-m",
+        "--max-depth",
+        dest="max_depth",
+        default=-1,
+        type=int,
+        help="the maximum depth for stepping into subdirectories, -1 disables this feature"
+    )
+    parser.add_argument(
+        "--paths-relative-to-input-dir",
+        dest="paths_relative_to_input_dir",
+        default=False,
+        action=BooleanOptionalAction,
+        type=bool,
+        help="when this is set, paths inside markdown files are interpreted as relative to the top level input"
+             " directory, otherwise, they are treated as relative to the markdown files they are contained in (default)"
+    )
+    return parser.parse_args()
+
+
+def handle_input_path(path):
+    if os.path.isdir(path):
+        return path
+    else:
+        raise argparse.ArgumentTypeError(f"'{path}' is not a valid path")
+
+
+def handle_output_path(path):
+    if os.path.isdir(path):
+        return path
+    else:
+        print("Output path does not yet exist. Creating...")
+        os.makedirs(path)
+        return path
+
+
+if __name__ == "__main__":
+    main(parse_args())

--- a/docs/user/document/acknowledgments-spec.en.md
+++ b/docs/user/document/acknowledgments-spec.en.md
@@ -8,4 +8,4 @@ Document acknowledgments (`acknowledgments`) of value type Acknowledgments Type 
 }
 ```
 
-[Specification of Acknowledgments Type](../types/acknowledgments-spec.en.md)
+[Specification of Acknowledgments Type](types/acknowledgments-spec.en.md)

--- a/docs/user/document/aggregate_severity-spec.en.md
+++ b/docs/user/document/aggregate_severity-spec.en.md
@@ -2,11 +2,11 @@
 
 Aggregate severity (`aggregate_severity`) of value type `object` with the mandatory property
 
-* [Text](aggregate_severity/text-spec.en.md) (`text`)
+* [Text](document/aggregate_severity/text-spec.en.md) (`text`)
 
 and the optional property
 
-* [Namespace](aggregate_severity/namespace-spec.en.md) (`namespace`)
+* [Namespace](document/aggregate_severity/namespace-spec.en.md) (`namespace`)
 
 is a vehicle that is provided by the document producer to convey the urgency and criticality with which the one or more vulnerabilities reported should be addressed.
 It is a document-level metric and applied to the document as a whole — not any specific vulnerability.

--- a/docs/user/document/distribution-spec.en.md
+++ b/docs/user/document/distribution-spec.en.md
@@ -2,8 +2,8 @@
 
 Rules for sharing document (`distribution`) of value type `object` with at least 1 of the 2 properties
 
-* [Text](distribution/text-spec.en.md) (`text`)
-* [Traffic Light Protocol (TLP)](distribution/tlp-spec.en.md) (`tlp`)
+* [Text](document/distribution/text-spec.en.md) (`text`)
+* [Traffic Light Protocol (TLP)](document/distribution/tlp-spec.en.md) (`tlp`)
 
 describes any constraints on how this document might be shared.
 

--- a/docs/user/document/distribution/tlp-spec.en.md
+++ b/docs/user/document/distribution/tlp-spec.en.md
@@ -2,11 +2,11 @@
 
 Traffic Light Protocol (TLP) (`tlp`) of value type `object` with the mandatory property
 
-* [Label](tlp/label-spec.en.md) (`label`)
+* [Label](document/distribution/tlp/label-spec.en.md) (`label`)
 
 and the optional property
 
-* [URL](tlp/url-spec.en.md) (`url`)
+* [URL](document/distribution/tlp/url-spec.en.md) (`url`)
 
 provides details about the TLP classification of the document.
 

--- a/docs/user/document/lang-spec.en.md
+++ b/docs/user/document/lang-spec.en.md
@@ -2,4 +2,4 @@
 
 Document language (`lang`) of value type Language Type (`lang_t`) identifies the language used by this document, corresponding to IETF BCP 47 / RFC 5646.
 
-[Specification of Language Type](../types/lang-spec.en.md)
+[Specification of Language Type](types/lang-spec.en.md)

--- a/docs/user/document/notes-spec.en.md
+++ b/docs/user/document/notes-spec.en.md
@@ -8,4 +8,4 @@ Document notes (`notes`) of value type Notes Type (`notes_t`) holds notes associ
 }
 ```
 
-[Specification of Notes Type](../types/notes-spec.en.md)
+[Specification of Notes Type](types/notes-spec.en.md)

--- a/docs/user/document/publisher-spec.en.md
+++ b/docs/user/document/publisher-spec.en.md
@@ -2,14 +2,14 @@
 
 Publisher (`publisher`) has value type `object` with the mandatory properties
 
-* [Category](publisher/category-spec.en.md) (`category`)
-* [Name](publisher/name-spec.en.md) (`name`)
-* [Namespace](publisher/namespace-spec.en.md) (`namespace`)
+* [Category](document/publisher/category-spec.en.md) (`category`)
+* [Name](document/publisher/name-spec.en.md) (`name`)
+* [Namespace](document/publisher/namespace-spec.en.md) (`namespace`)
 
 and provides information on the publishing entity. The 2 other optional properties are:
 
-* [Contact Details](publisher/issuing_authority-spec.en.md) (`contact_details`)
-* [Issuing Authority](publisher/issuing_authority-spec.en.md) (`issuing_authority`)
+* [Contact Details](document/publisher/issuing_authority-spec.en.md) (`contact_details`)
+* [Issuing Authority](document/publisher/issuing_authority-spec.en.md) (`issuing_authority`)
 
 ```javascript
 "publisher": {

--- a/docs/user/document/references-spec.en.md
+++ b/docs/user/document/references-spec.en.md
@@ -8,4 +8,4 @@ Document references (`references`) of value type References Type (`references_t`
 }
 ```
 
-[Specification of References Type](../types/references-spec.en.md)
+[Specification of References Type](types/references-spec.en.md)

--- a/docs/user/document/tracking-spec.en.md
+++ b/docs/user/document/tracking-spec.en.md
@@ -2,17 +2,17 @@
 
 Tracking (`tracking`) of value type `object` with the six mandatory properties:
 
-* [Current Release Date](tracking/current_release_date-spec.en.md) (`current_release_date`)
-* [Identifier](tracking/id-spec.en.md) (`id`)
-* [Initial Release Date](tracking/initial_release_date-spec.en.md) (`initial_release_date`)
-* [Revision History](tracking/revision_history-spec.en.md) (`revision_history`)
-* [Status](tracking/status-spec.en.md) (`status`)
-* [Version](tracking/version-spec.en.md) (`version`)
+* [Current Release Date](document/tracking/current_release_date-spec.en.md) (`current_release_date`)
+* [Identifier](document/tracking/id-spec.en.md) (`id`)
+* [Initial Release Date](document/tracking/initial_release_date-spec.en.md) (`initial_release_date`)
+* [Revision History](document/tracking/revision_history-spec.en.md) (`revision_history`)
+* [Status](document/tracking/status-spec.en.md) (`status`)
+* [Version](document/tracking/version-spec.en.md) (`version`)
 
 is a container designated to hold all management attributes necessary to track a CSAF document as a whole. The two optional additional properties are
 
-* [Aliases](tracking/aliases-spec.en.md) (`aliases`)
-* [Generator](tracking/generator-spec.en.md) (`generator`).
+* [Aliases](document/tracking/aliases-spec.en.md) (`aliases`)
+* [Generator](document/tracking/generator-spec.en.md) (`generator`).
 
 ```javascript
 "tracking": {

--- a/docs/user/document/tracking/aliases-spec.en.md
+++ b/docs/user/document/tracking/aliases-spec.en.md
@@ -11,4 +11,4 @@ Aliases (`aliases`) of value type `array` with 1 or more unique items (a `set`) 
 }
 ```
 
-[Specification of Alias items](aliases/alias-spec.en.md)
+[Specification of Alias items](document/tracking/aliases/alias-spec.en.md)

--- a/docs/user/document/tracking/generator-spec.en.md
+++ b/docs/user/document/tracking/generator-spec.en.md
@@ -2,11 +2,11 @@
 
 Document Generator (`generator`) of value type `object` with mandatory property
 
-* [Engine](generator/engine-spec.en.md) (`engine`)
+* [Engine](document/tracking/generator/engine-spec.en.md) (`engine`)
 
 and optional property
 
-* [Date](generator/date-spec.en.md) (`date`)
+* [Date](document/tracking/generator/date-spec.en.md) (`date`)
 
 is a container to hold all elements related to the generation of the document.
 These items will reference when the document was actually created, including the date it was generated and the entity that generated it.

--- a/docs/user/document/tracking/generator/engine-spec.en.md
+++ b/docs/user/document/tracking/generator/engine-spec.en.md
@@ -2,11 +2,11 @@
 
 Engine of document generation (`engine`) of value type `object` with mandatory property
 
-* [Engine Name](engine/name-spec.en.md) (`name`)
+* [Engine Name](document/tracking/generator/engine/name-spec.en.md) (`name`)
 
 and optional property
 
-* [Engine version](engine/version-spec.en.md) (`version`)
+* [Engine version](document/tracking/generator/engine/version-spec.en.md) (`version`)
 
 contains information about the engine that generated the CSAF document.
 

--- a/docs/user/document/tracking/revision_history-spec.en.md
+++ b/docs/user/document/tracking/revision_history-spec.en.md
@@ -11,4 +11,4 @@ The Revision History (`revision_history`) with value type `array` of 1 or more R
 }
 ```
 
-[Specification of Revision items](revision_history/revision-spec.en.md)
+[Specification of Revision items](document/tracking/revision_history/revision-spec.en.md)

--- a/docs/user/document/tracking/revision_history/revision-spec.en.md
+++ b/docs/user/document/tracking/revision_history/revision-spec.en.md
@@ -3,13 +3,13 @@
 Each Revision contains all the information elements required to track the evolution of a CSAF document.
 Revision History Entry items are of value type `object` with the three mandatory properties:
 
-* [Date](revision/date-spec.en.md) (`date`)
-* [Number](revision/number-spec.en.md) (`number`)
-* [Summary](revision/summary-spec.en.md) (`summary`)
+* [Date](document/tracking/revision_history/revision/date-spec.en.md) (`date`)
+* [Number](document/tracking/revision_history/revision/number-spec.en.md) (`number`)
+* [Summary](document/tracking/revision_history/revision/summary-spec.en.md) (`summary`)
 
 In addition, a Revision MAY expose the optional property
 
-* [Legacy Version](revision/legacy_version-spec.en.md) `legacy_version`
+* [Legacy Version](document/tracking/revision_history/revision/legacy_version-spec.en.md) `legacy_version`
 
 ```javascript
 "properties": {

--- a/docs/user/document/tracking/revision_history/revision/number-spec.en.md
+++ b/docs/user/document/tracking/revision_history/revision/number-spec.en.md
@@ -2,4 +2,4 @@
 
 The Number (`number`) has value type Version (`version_t`).
 
-[Specification of Version Type](../../../../types/version-spec.en.md)
+[Specification of Version Type](types/version-spec.en.md)

--- a/docs/user/document/tracking/version-spec.en.md
+++ b/docs/user/document/tracking/version-spec.en.md
@@ -2,4 +2,4 @@
 
 Version has the value type Version (`version_t`).
 
-[Specification of Version Type](../../types/version-spec.en.md)
+[Specification of Version Type](types/version-spec.en.md)

--- a/docs/user/product_tree/branches-spec.en.md
+++ b/docs/user/product_tree/branches-spec.en.md
@@ -2,4 +2,4 @@
 
 List of branches (`branches`) has the value type `branches_t`.
 
-[Specification of Branches Type](../types/branches)
+[Specification of Branches Type](types/branches)

--- a/docs/user/product_tree/full_product_names-spec.en.md
+++ b/docs/user/product_tree/full_product_names-spec.en.md
@@ -2,4 +2,4 @@
 
 List of full product names (`full_product_names`) of value type array with 1 or more items of type `full_product_name_t` contains a list of full product names.
 
-[Specification of Full Product Name Type](../types/full_product_name-spec.en.md)
+[Specification of Full Product Name Type](types/full_product_name-spec.en.md)

--- a/docs/user/product_tree/product_groups-spec.en.md
+++ b/docs/user/product_tree/product_groups-spec.en.md
@@ -11,4 +11,4 @@ List of product groups (`product_groups`) of value type `array` with 1 or more i
 }
 ```
 
-[Specification of Product Group items](product_groups/product_group-spec.en.md)
+[Specification of Product Group items](product_tree/product_groups/product_group-spec.en.md)

--- a/docs/user/product_tree/product_groups/product_group-spec.en.md
+++ b/docs/user/product_tree/product_groups/product_group-spec.en.md
@@ -2,12 +2,12 @@
 
 The product group items are of value type `object` with the 2 mandatory properties
 
-* [Group ID](product_group/group_id-spec.en.md) (`group_id`)
-* [Product IDs](product_group/product_ids-spec.en.md) (`product_ids`)
+* [Group ID](product_tree/product_groups/product_group/group_id-spec.en.md) (`group_id`)
+* [Product IDs](product_tree/product_groups/product_group/product_ids-spec.en.md) (`product_ids`)
 
 and the optional
 
-* [Summary](product_group/summary-spec.en.md) (`summary`)
+* [Summary](product_tree/product_groups/product_group/summary-spec.en.md) (`summary`)
 
 property.
 

--- a/docs/user/product_tree/product_groups/product_group/group_id-spec.en.md
+++ b/docs/user/product_tree/product_groups/product_group/group_id-spec.en.md
@@ -2,4 +2,4 @@
 
 Group ID (`group_id`) has value type Product Group ID (`product_group_id_t`).
 
-[Specification of Product Group ID Type](../../../types/product_group_id-spec.en.md)
+[Specification of Product Group ID Type](types/product_group_id-spec.en.md)

--- a/docs/user/product_tree/product_groups/product_group/product_ids-spec.en.md
+++ b/docs/user/product_tree/product_groups/product_group/product_ids-spec.en.md
@@ -2,4 +2,4 @@
 
 List of Product IDs (`product_ids`) of value type array with 2 or more unique items of value type Product ID (`product_id_t`) lists the product_ids of those products which known as one group in the document.
 
-[Specification of Product ID Type](../../../types/product_id-spec.en.md)
+[Specification of Product ID Type](types/product_id-spec.en.md)

--- a/docs/user/product_tree/relationships-spec.en.md
+++ b/docs/user/product_tree/relationships-spec.en.md
@@ -11,4 +11,4 @@ List of relationships (`relationships`) of value type `array` with 1 or more ite
 }
 ```
 
-[Specification of Relationship items](relationships/relationship-spec.en.md)
+[Specification of Relationship items](product_tree/relationships/relationship-spec.en.md)

--- a/docs/user/product_tree/relationships/relationship-spec.en.md
+++ b/docs/user/product_tree/relationships/relationship-spec.en.md
@@ -2,10 +2,10 @@
 
 The Relationship item is of value type `object` and has four mandatory properties:
 
-* [Relationship category](relationship/category-spec.en.md) (`category`)
-* [Full Product Name](relationship/full_product_name-spec.en.md) (`full_product_name`)
-* [Product Reference](relationship/product_reference-spec.en.md) (`product_reference`)
-* [Relates to Product Reference](relationship/relates_to_product_reference-spec.en.md) (`relates_to_product_reference`)
+* [Relationship category](product_tree/relationships/relationship/category-spec.en.md) (`category`)
+* [Full Product Name](product_tree/relationships/relationship/full_product_name-spec.en.md) (`full_product_name`)
+* [Product Reference](product_tree/relationships/relationship/product_reference-spec.en.md) (`product_reference`)
+* [Relates to Product Reference](product_tree/relationships/relationship/relates_to_product_reference-spec.en.md) (`relates_to_product_reference`)
 
 The Relationship item establishes a link between two existing `full_product_name_t` elements, allowing the document producer to define a combination of two products that form a new `full_product_name` entry.
 

--- a/docs/user/product_tree/relationships/relationship/full_product_name-spec.en.md
+++ b/docs/user/product_tree/relationships/relationship/full_product_name-spec.en.md
@@ -2,4 +2,4 @@
 
 Full Product Name (`full_product_name`) of value type Full Product Name Type (`full_product_name_t`).
 
-[Specification of Full Product Name Type](../../../types/full_product_name-spec.en.md)
+[Specification of Full Product Name Type](types/full_product_name-spec.en.md)

--- a/docs/user/product_tree/relationships/relationship/product_reference-spec.en.md
+++ b/docs/user/product_tree/relationships/relationship/product_reference-spec.en.md
@@ -2,4 +2,4 @@
 
 Product Reference (`product_reference`) of value type Product ID (`product_id_t`) holds a Product ID that refers to the Full Product Name element, which is referenced as the first element of the relationship.
 
-[Specification of Product ID Type](../../../types/product_id-spec.en.md)
+[Specification of Product ID Type](types/product_id-spec.en.md)

--- a/docs/user/product_tree/relationships/relationship/relates_to_product_reference-spec.en.md
+++ b/docs/user/product_tree/relationships/relationship/relates_to_product_reference-spec.en.md
@@ -2,4 +2,4 @@
 
 Relates to Product Reference (`relates_to_product_reference`) of value type Product ID (`product_id_t`) holds a Product ID that refers to the Full Product Name element, which is referenced as the second element of the relationship.
 
-[Specification of Product ID Type](../../../types/product_id-spec.en.md)
+[Specification of Product ID Type](types/product_id-spec.en.md)

--- a/docs/user/types/acknowledgments-spec.en.md
+++ b/docs/user/types/acknowledgments-spec.en.md
@@ -11,4 +11,4 @@ List of Acknowledgments (`acknowledgments_t`) type instance of value type `array
 }
 ```
 
-[Specification of Acknowledgment items](acknowledgments/acknowledgment-spec.en.md)
+[Specification of Acknowledgment items](types/acknowledgments/acknowledgment-spec.en.md)

--- a/docs/user/types/acknowledgments/acknowledgment-spec.en.md
+++ b/docs/user/types/acknowledgments/acknowledgment-spec.en.md
@@ -4,10 +4,10 @@ The value type of Acknowledgment is `object` with at least 1 and at most 4 prope
 Every such element acknowledges contributions by describing those that contributed.
 The properties are:
 
-* [Names](acknowledgment/names-spec.en.md) (`names`)
-* [Organization](acknowledgment/organization-spec.en.md) (`organization`)
-* [Summary](acknowledgment/summary-spec.en.md) (`summary`)
-* [URLs](acknowledgment/urls-spec.en.md) (`urls`)
+* [Names](types/acknowledgments/acknowledgment/names-spec.en.md) (`names`)
+* [Organization](types/acknowledgments/acknowledgment/organization-spec.en.md) (`organization`)
+* [Summary](types/acknowledgments/acknowledgment/summary-spec.en.md) (`summary`)
+* [URLs](types/acknowledgments/acknowledgment/urls-spec.en.md) (`urls`)
 
 ```javascript
 "properties": {

--- a/docs/user/types/acknowledgments/acknowledgment/names-spec.en.md
+++ b/docs/user/types/acknowledgments/acknowledgment/names-spec.en.md
@@ -2,4 +2,4 @@
 
 List of acknowledged names (`names`) has value type `array` with 1 or more items holds the names of entities being recognized.
 
-[Specification of Name items](names/name-spec.en.md)
+[Specification of Name items](types/acknowledgments/acknowledgment/names/name-spec.en.md)

--- a/docs/user/types/acknowledgments/acknowledgment/urls-spec.en.md
+++ b/docs/user/types/acknowledgments/acknowledgment/urls-spec.en.md
@@ -2,4 +2,4 @@
 
 List of URLs (`urls`) of acknowledgment is a container (value type `array`) for 1 or more `string` of type URL that specifies a list of URLs or location of the reference to be acknowledged.
 
-[Specification of URL items](urls/url-spec.en.md)
+[Specification of URL items](types/acknowledgments/acknowledgment/urls/url-spec.en.md)

--- a/docs/user/types/branches-spec.en.md
+++ b/docs/user/types/branches-spec.en.md
@@ -11,4 +11,4 @@ List of branches(`branches_t`) with value type `array` contains 1 or more branch
 }
 ```
 
-[Specification of Branch items](branches/branch-spec.en.md)
+[Specification of Branch items](types/branches/branch-spec.en.md)

--- a/docs/user/types/branches/branch-spec.en.md
+++ b/docs/user/types/branches/branch-spec.en.md
@@ -3,17 +3,17 @@
 Every Branch holds exactly 3 properties and is a part of the hierarchical structure of the product tree.
 The properties
 
-* [Name](branch/name-spec.en.md) (`name`)
-* [Category](branch/category-spec.en.md) (`category`)
+* [Name](types/branches/branch/name-spec.en.md) (`name`)
+* [Category](types/branches/branch/category-spec.en.md) (`category`)
 
 are mandatory.
 In addition, the object contains either a
 
-* [Branches](../branches-spec.en.md) (`branches`)
+* [Branches](product_tree/branches-spec.en.md) (`branches`)
 
 or a
 
-* [Product](branch/product-spec.en.md) `product` property.
+* [Product](types/branches/branch/product-spec.en.md) `product` property.
 
 ```javascript
 "properties": {

--- a/docs/user/types/branches/branch/product-spec.en.md
+++ b/docs/user/types/branches/branch/product-spec.en.md
@@ -2,4 +2,4 @@
 
 Product (`product`) has the value type Full Product Name (`full_product_name_t`).
 
-[Specification of Full Product Name](../../full_product_name-spec.en.md)
+[Specification of Full Product Name](types/full_product_name-spec.en.md)

--- a/docs/user/types/full_product_name-spec.en.md
+++ b/docs/user/types/full_product_name-spec.en.md
@@ -2,12 +2,12 @@
 
 Full Product Name (`full_product_name_t`) with value type `object` specifies information about the product and assigns the product ID. The properties
 
-* [Name](full_product_name/name-spec.en.md) (`name`)
-* [Product ID](full_product_name/product_id-spec.en.md) (`product_id`)
+* [Name](types/full_product_name/name-spec.en.md) (`name`)
+* [Product ID](types/full_product_name/product_id-spec.en.md) (`product_id`)
 
 are required. The property
 
-* [Product Identification Helper](full_product_name/product_identification_helper-spec.en.md)
+* [Product Identification Helper](types/full_product_name/product_identification_helper-spec.en.md)
   (`product_identification_helper`)
 
 is optional.

--- a/docs/user/types/full_product_name/product_id-spec.en.md
+++ b/docs/user/types/full_product_name/product_id-spec.en.md
@@ -2,4 +2,4 @@
 
 Product ID (`product_id`) holds a value of type Product ID (`product_id_t`).
 
-[Specification of Product ID Type](../product_id-spec.en.md)
+[Specification of Product ID Type](types/product_id-spec.en.md)

--- a/docs/user/types/full_product_name/product_identification_helper-spec.en.md
+++ b/docs/user/types/full_product_name/product_identification_helper-spec.en.md
@@ -3,14 +3,14 @@
 Helper to identify the product (`product_identification_helper`) of value type `object` provides in its properties at least one method which aids in identifying the product in an asset database.
 Of the given eight properties
 
-* [CPE](product_identification_helper/cpe-spec.en.md) (`cpe`)
-* [Hashes](product_identification_helper/hashes-spec.en.md) (`hashes`)
-* [Model Numbers](product_identification_helper/model_numbers-spec.en.md) (`model_numbers`)
-* [Package URL](product_identification_helper/purl-spec.en.md) (`purl`)
-* [SBOM URLs](product_identification_helper/sbom_urls-spec.en.md) (`sbom_urls`)
-* [Serial Numbers](product_identification_helper/serial_numbers-spec.en.md) (`serial_numbers`)
-* [SKUs](product_identification_helper/skus-spec.en.md) (`skus`)
-* [X Generic URIs](product_identification_helper/x_generic_uris-spec.en.md) (`x_generic_uris`)
+* [CPE](types/full_product_name/product_identification_helper/cpe-spec.en.md) (`cpe`)
+* [Hashes](types/full_product_name/product_identification_helper/hashes-spec.en.md) (`hashes`)
+* [Model Numbers](types/full_product_name/product_identification_helper/model_numbers-spec.en.md) (`model_numbers`)
+* [Package URL](types/full_product_name/product_identification_helper/purl-spec.en.md) (`purl`)
+* [SBOM URLs](types/full_product_name/product_identification_helper/sbom_urls-spec.en.md) (`sbom_urls`)
+* [Serial Numbers](types/full_product_name/product_identification_helper/serial_numbers-spec.en.md) (`serial_numbers`)
+* [SKUs](types/full_product_name/product_identification_helper/skus-spec.en.md) (`skus`)
+* [X Generic URIs](types/full_product_name/product_identification_helper/x_generic_uris-spec.en.md) (`x_generic_uris`)
 
 one is mandatory.
 

--- a/docs/user/types/full_product_name/product_identification_helper/hashes-spec.en.md
+++ b/docs/user/types/full_product_name/product_identification_helper/hashes-spec.en.md
@@ -11,4 +11,4 @@ List of hashes (`hashes`) of value type `array` holding at least one item contai
 }
 ```
 
-[Specification of Hash items](hashes/hash-spec.en.md)
+[Specification of Hash items](types/full_product_name/product_identification_helper/hashes/hash-spec.en.md)

--- a/docs/user/types/full_product_name/product_identification_helper/hashes/hash-spec.en.md
+++ b/docs/user/types/full_product_name/product_identification_helper/hashes/hash-spec.en.md
@@ -3,8 +3,8 @@
 Cryptographic hashes of value type `object` contains all information to identify a file based on its cryptographic hash values.
 Any cryptographic hashes object has the 2 mandatory properties
 
-* [File Hashes](hash/file_hashes-spec.en.md) (`file_hashes`)
-* [File Name](hash/filename-spec.en.md) (`filename`)
+* [File Hashes](types/full_product_name/product_identification_helper/hashes/hash/file_hashes-spec.en.md) (`file_hashes`)
+* [File Name](types/full_product_name/product_identification_helper/hashes/hash/filename-spec.en.md) (`filename`)
 
 ```javascript
 "properties": {

--- a/docs/user/types/full_product_name/product_identification_helper/hashes/hash/file_hashes-spec.en.md
+++ b/docs/user/types/full_product_name/product_identification_helper/hashes/hash/file_hashes-spec.en.md
@@ -11,4 +11,4 @@ List of file hashes (`file_hashes`) of value type `array` holding at least one i
 }
 ```
 
-[Specification of File Hash items](file_hashes/file_hash-spec.en.md)
+[Specification of File Hash items](types/full_product_name/product_identification_helper/hashes/hash/file_hashes/file_hash-spec.en.md)

--- a/docs/user/types/full_product_name/product_identification_helper/hashes/hash/file_hashes/file_hash-spec.en.md
+++ b/docs/user/types/full_product_name/product_identification_helper/hashes/hash/file_hashes/file_hash-spec.en.md
@@ -3,8 +3,8 @@
 Each File hash of value type `object` contains one hash value and algorithm of the file to be identified.
 Any File hash object has the 2 mandatory properties
 
-* [Algorithm](file_hash/algorithm-spec.en.md) (`algorithm`)
-* [Value](file_hash/value-spec.en.md) (`value`)
+* [Algorithm](types/full_product_name/product_identification_helper/hashes/hash/file_hashes/file_hash/algorithm-spec.en.md) (`algorithm`)
+* [Value](types/full_product_name/product_identification_helper/hashes/hash/file_hashes/file_hash/value-spec.en.md) (`value`)
 
 ```javascript
 "properties": {

--- a/docs/user/types/full_product_name/product_identification_helper/model_numbers-spec.en.md
+++ b/docs/user/types/full_product_name/product_identification_helper/model_numbers-spec.en.md
@@ -15,4 +15,4 @@ This can also be used to identify hardware. If necessary, the software, or any o
 }
 ```
 
-[Specification of Model Number items](model_numbers/model_number-spec.en.md)
+[Specification of Model Number items](types/full_product_name/product_identification_helper/model_numbers/model_number-spec.en.md)

--- a/docs/user/types/full_product_name/product_identification_helper/sbom_urls-spec.en.md
+++ b/docs/user/types/full_product_name/product_identification_helper/sbom_urls-spec.en.md
@@ -13,4 +13,4 @@ The list of SBOM URLs (`sbom_urls`) of value type `array` with 1 or more items c
 }
 ```
 
-[Specification of SBOM URL items](sbom_urls/sbom_url-spec.en.md)
+[Specification of SBOM URL items](types/full_product_name/product_identification_helper/sbom_urls/sbom_url-spec.en.md)

--- a/docs/user/types/full_product_name/product_identification_helper/serial_numbers-spec.en.md
+++ b/docs/user/types/full_product_name/product_identification_helper/serial_numbers-spec.en.md
@@ -13,4 +13,4 @@ A list of serial numbers SHOULD only be used if a certain range of serial number
 }
 ```
 
-[Specification of Serial Number items](serial_numbers/serial_number-spec.en.md)
+[Specification of Serial Number items](types/full_product_name/product_identification_helper/serial_numbers/serial_number-spec.en.md)

--- a/docs/user/types/full_product_name/product_identification_helper/skus-spec.en.md
+++ b/docs/user/types/full_product_name/product_identification_helper/skus-spec.en.md
@@ -17,4 +17,4 @@ In the latter case the remediations SHALL include the new stock keeping units is
 }
 ```
 
-[Specification of SKU items](skus/sku-spec.en.md)
+[Specification of SKU items](types/full_product_name/product_identification_helper/skus/sku-spec.en.md)

--- a/docs/user/types/full_product_name/product_identification_helper/x_generic_uris-spec.en.md
+++ b/docs/user/types/full_product_name/product_identification_helper/x_generic_uris-spec.en.md
@@ -11,4 +11,4 @@ List of generic URIs (`x_generic_uris`) of value type `array` with at least 1 it
 }
 ```
 
-[Specification of generic URI items](x_generic_uris/x_generic_uri-spec.en.md)
+[Specification of generic URI items](types/full_product_name/product_identification_helper/x_generic_uris/x_generic_uri-spec.en.md)

--- a/docs/user/types/full_product_name/product_identification_helper/x_generic_uris/x_generic_uri-spec.en.md
+++ b/docs/user/types/full_product_name/product_identification_helper/x_generic_uris/x_generic_uri-spec.en.md
@@ -2,8 +2,8 @@
 
 Any such Generic URI item of value type `object` provides the two mandatory properties
 
-* [Namespace](x_generic_uri/namespace-spec.en.md) (`namespace`)
-* [URI](x_generic_uri/uri-spec.en.md) (`uri`)
+* [Namespace](types/full_product_name/product_identification_helper/x_generic_uris/x_generic_uri/namespace-spec.en.md) (`namespace`)
+* [URI](types/full_product_name/product_identification_helper/x_generic_uris/x_generic_uri/uri-spec.en.md) (`uri`)
 
 ```javascript
 "properties": {

--- a/docs/user/types/notes-spec.en.md
+++ b/docs/user/types/notes-spec.en.md
@@ -11,4 +11,4 @@ List of notes (`notes_t`) of value type array with 1 or more items of type `Note
 }
 ```
 
-[Specification of Note items](notes/note-spec.en.md)
+[Specification of Note items](types/notes/note-spec.en.md)

--- a/docs/user/types/notes/note-spec.en.md
+++ b/docs/user/types/notes/note-spec.en.md
@@ -2,14 +2,14 @@
 
 Value type of every such Note item is `object` with the mandatory properties
 
-* [Category](note/category-spec.en.md) (`category`)
-* [Text](note/text-spec.en.md) (`text`)
+* [Category](types/notes/note/category-spec.en.md) (`category`)
+* [Text](types/notes/note/text-spec.en.md) (`text`)
 
 providing a place to put all manner of text blobs related to the current context.
 A Note `object` MAY provide the optional properties
 
-* [Audience](note/audience-spec.en.md) (`audience`)
-* [Title](note/title-spec.en.md) (`title`)
+* [Audience](types/notes/note/audience-spec.en.md) (`audience`)
+* [Title](types/notes/note/title-spec.en.md) (`title`)
 
 ```javascript
 "properties": {

--- a/docs/user/types/product_groups-spec.en.md
+++ b/docs/user/types/product_groups-spec.en.md
@@ -11,4 +11,4 @@ List of Product Group ID (`product_groups_t`) of value type `array` with 1 or mo
 }
 ```
 
-[Specification of Product Group ID items](product_group_id-spec.en.md)
+[Specification of Product Group ID items](types/product_group_id-spec.en.md)

--- a/docs/user/types/products-spec.en.md
+++ b/docs/user/types/products-spec.en.md
@@ -11,4 +11,4 @@ List of Product IDs (`products_t`) of value type `array` with 1 or more unique i
 }
 ```
 
-[Specification fo Product ID items](product_id-spec.en.md)
+[Specification fo Product ID items](types/product_id-spec.en.md)

--- a/docs/user/types/references-spec.en.md
+++ b/docs/user/types/references-spec.en.md
@@ -11,4 +11,4 @@ List of references (`references_t`) of value type `array` with 1 or more items o
 }
 ```
 
-[Specification of Reference items](references/reference-spec.en.md)
+[Specification of Reference items](types/references/reference-spec.en.md)

--- a/docs/user/types/references/reference-spec.en.md
+++ b/docs/user/types/references/reference-spec.en.md
@@ -2,13 +2,13 @@
 
 Value type of every such Reference item is `object` with the mandatory properties
 
-* [URL](reference/url-spec.en.md) (`url`)
-* [Summary](reference/summary-spec.en.md) (`summary`)
+* [URL](types/references/reference/url-spec.en.md) (`url`)
+* [Summary](types/references/reference/summary-spec.en.md) (`summary`)
 
 holding any reference to conferences, papers, advisories, and other resources that are related and considered related to either a surrounding part of or the entire document and to be of value to the document consumer.
 A reference `object` MAY provide the optional property
 
-* [Category](reference/category-spec.en.md) (`category`)
+* [Category](types/references/reference/category-spec.en.md) (`category`)
 
 ```javascript
 "properties": {

--- a/docs/user/vulnerabilities/vulnerability-spec.en.md
+++ b/docs/user/vulnerabilities/vulnerability-spec.en.md
@@ -3,21 +3,21 @@
 The Vulnerability item of value type `object` with 1 or more properties is a container for the aggregation of all fields that are related to a single vulnerability in the document.
 Any vulnerability MAY provide the optional properties
 
-* [Acknowledgments](vulnerability/acknowledgments-spec.en.md) (`acknowledgments`)
-* [Common Vulnerabilities and Exposures (CVE)](vulnerability/cve-spec.en.md) (`cve`)
-* [Common Weakness Enumeration (CWE)](vulnerability/cwe-spec.en.md) (`cwe`)
-* [Discovery Date](vulnerability/discovery_date-spec.en.md) (`discovery_date`)
-* [Flags](vulnerability/flags-spec.en.md) (`flags`)
-* [IDs](vulnerability/ids-spec.en.md) (`ids`)
-* [Involvements](vulnerability/involvements-spec.en.md) (`involvements`)
-* [Notes](vulnerability/notes-spec.en.md) (`notes`)
-* [Product Status](vulnerability/product_status-spec.en.md) (`product_status`)
-* [References](vulnerability/references-spec.en.md) (`references`)
-* [Release Date](vulnerability/release_date-spec.en.md) (`release_date`)
-* [Remediations](vulnerability/remediations-spec.en.md) (`remediations`)
-* [Scores](vulnerability/scores-spec.en.md) (`scores`)
-* [Threats](vulnerability/threats-spec.en.md) (`threats`)
-* [Title](vulnerability/title-spec.en.md) (`title`)
+* [Acknowledgments](vulnerabilities/vulnerability/acknowledgments-spec.en.md) (`acknowledgments`)
+* [Common Vulnerabilities and Exposures (CVE)](vulnerabilities/vulnerability/cve-spec.en.md) (`cve`)
+* [Common Weakness Enumeration (CWE)](vulnerabilities/vulnerability/cwe-spec.en.md) (`cwe`)
+* [Discovery Date](vulnerabilities/vulnerability/discovery_date-spec.en.md) (`discovery_date`)
+* [Flags](vulnerabilities/vulnerability/flags-spec.en.md) (`flags`)
+* [IDs](vulnerabilities/vulnerability/ids-spec.en.md) (`ids`)
+* [Involvements](vulnerabilities/vulnerability/involvements-spec.en.md) (`involvements`)
+* [Notes](vulnerabilities/vulnerability/notes-spec.en.md) (`notes`)
+* [Product Status](vulnerabilities/vulnerability/product_status-spec.en.md) (`product_status`)
+* [References](vulnerabilities/vulnerability/references-spec.en.md) (`references`)
+* [Release Date](vulnerabilities/vulnerability/release_date-spec.en.md) (`release_date`)
+* [Remediations](vulnerabilities/vulnerability/remediations-spec.en.md) (`remediations`)
+* [Scores](vulnerabilities/vulnerability/scores-spec.en.md) (`scores`)
+* [Threats](vulnerabilities/vulnerability/threats-spec.en.md) (`threats`)
+* [Title](vulnerabilities/vulnerability/title-spec.en.md) (`title`)
 
 ```javascript
 "properties": {

--- a/docs/user/vulnerabilities/vulnerability/acknowledgments-spec.en.md
+++ b/docs/user/vulnerabilities/vulnerability/acknowledgments-spec.en.md
@@ -8,4 +8,4 @@ Vulnerability acknowledgments (`acknowledgments`) of value type Acknowledgments 
 }
 ```
 
-[Specification of Acknowledgments Type](../../types/acknowledgments-spec.en.md)
+[Specification of Acknowledgments Type](types/acknowledgments-spec.en.md)

--- a/docs/user/vulnerabilities/vulnerability/cwe-spec.en.md
+++ b/docs/user/vulnerabilities/vulnerability/cwe-spec.en.md
@@ -2,8 +2,8 @@
 
 CWE (`cwe`) of value type `object` with the 2 mandatory properties
 
-* [Weakness ID](cwe/id-spec.en.md) (`id`)
-* [Weakness Name](cwe/name-spec.en.md) (`name`)
+* [Weakness ID](vulnerabilities/vulnerability/cwe/id-spec.en.md) (`id`)
+* [Weakness Name](vulnerabilities/vulnerability/cwe/name-spec.en.md) (`name`)
 
 holds the MITRE standard Common Weakness Enumeration (CWE) for the weakness associated. For more information cf. [[CWE]](#cwe).
 

--- a/docs/user/vulnerabilities/vulnerability/flags-spec.en.md
+++ b/docs/user/vulnerabilities/vulnerability/flags-spec.en.md
@@ -11,4 +11,4 @@ List of flags (`flags`) of value type `array` with 1 or more unique items (a set
 }
 ```
 
-[Specification of Flag items](flags/flag-spec.en.md)
+[Specification of Flag items](vulnerabilities/vulnerability/flags/flag-spec.en.md)

--- a/docs/user/vulnerabilities/vulnerability/flags/flag-spec.en.md
+++ b/docs/user/vulnerabilities/vulnerability/flags/flag-spec.en.md
@@ -2,7 +2,7 @@
 
 Every Flag item of value type `object` with the mandatory property
 
-* [Label](flag/label-spec.en.md) (`label`)
+* [Label](vulnerabilities/vulnerability/flags/flag/label-spec.en.md) (`label`)
 
 contains product specific information in regard to this vulnerability as a single machine readable flag. For example, this could be a machine readable justification code why a product is not affected.
 
@@ -10,9 +10,9 @@ contains product specific information in regard to this vulnerability as a singl
 
 In addition, any Flag items MAY provide the three optional properties
 
-* [Date](flag/date-spec.en.md) (`date`)
-* [Group IDs](flag/group_ids-spec.en.md) (`group_ids`)
-* [Product IDs](flag/product_ids-spec.en.md) (`product_ids`)
+* [Date](vulnerabilities/vulnerability/flags/flag/date-spec.en.md) (`date`)
+* [Group IDs](vulnerabilities/vulnerability/flags/flag/group_ids-spec.en.md) (`group_ids`)
+* [Product IDs](vulnerabilities/vulnerability/flags/flag/product_ids-spec.en.md) (`product_ids`)
 
 ```javascript
 "properties": {

--- a/docs/user/vulnerabilities/vulnerability/flags/flag/group_ids-spec.en.md
+++ b/docs/user/vulnerabilities/vulnerability/flags/flag/group_ids-spec.en.md
@@ -2,4 +2,4 @@
 
 Group IDs (`group_ids`) are of value type Product Groups (`product_groups_t`).
 
-[Specification of Product Groups Type](../../../../types/product_groups-spec.en.md)
+[Specification of Product Groups Type](types/product_groups-spec.en.md)

--- a/docs/user/vulnerabilities/vulnerability/flags/flag/product_ids-spec.en.md
+++ b/docs/user/vulnerabilities/vulnerability/flags/flag/product_ids-spec.en.md
@@ -2,4 +2,4 @@
 
 Product IDs (`product_ids`) are of value type Products (`products_t`).
 
-[Specification of Product IDs Type](../../../../types/products-spec.en.md)
+[Specification of Product IDs Type](types/products-spec.en.md)

--- a/docs/user/vulnerabilities/vulnerability/ids-spec.en.md
+++ b/docs/user/vulnerabilities/vulnerability/ids-spec.en.md
@@ -11,4 +11,4 @@ List of IDs (`ids`) of value type `array` with one or more unique ID items of va
 }
 ```
 
-[Specification of ID items](ids/id-spec.en.md)
+[Specification of ID items](vulnerabilities/vulnerability/ids/id-spec.en.md)

--- a/docs/user/vulnerabilities/vulnerability/ids/id-spec.en.md
+++ b/docs/user/vulnerabilities/vulnerability/ids/id-spec.en.md
@@ -2,8 +2,8 @@
 
 Every ID item of value type `object` with the two mandatory properties
 
-* [System Name](id/system_name-spec.en.md) (`system_name`)
-* [Text](id/text-spec.en.md) (`text`)
+* [System Name](vulnerabilities/vulnerability/ids/id/system_name-spec.en.md) (`system_name`)
+* [Text](vulnerabilities/vulnerability/ids/id/text-spec.en.md) (`text`)
 
 contains a single unique label or tracking ID for the vulnerability.
 

--- a/docs/user/vulnerabilities/vulnerability/involvements-spec.en.md
+++ b/docs/user/vulnerabilities/vulnerability/involvements-spec.en.md
@@ -11,4 +11,4 @@ List of involvements (`involvements`) of value type `array` with 1 or more items
 }
 ```
 
-[Specification of Involvement items](involvements/involvement-spec.en.md)
+[Specification of Involvement items](vulnerabilities/vulnerability/involvements/involvement-spec.en.md)

--- a/docs/user/vulnerabilities/vulnerability/involvements/involvement-spec.en.md
+++ b/docs/user/vulnerabilities/vulnerability/involvements/involvement-spec.en.md
@@ -2,13 +2,13 @@
 
 Every Involvement item of value type `object` with the 2 mandatory properties
 
-* [Party](involvement/party-spec.en.md) (`party`)
-* [Status](involvement/status-spec.en.md) (`status`)
+* [Party](vulnerabilities/vulnerability/involvements/involvement/party-spec.en.md) (`party`)
+* [Status](vulnerabilities/vulnerability/involvements/involvement/status-spec.en.md) (`status`)
 
 and the 2 optional properties
 
-* [Date of involvement](involvement/date-spec.en.md) (`date`)
-* [Summary](involvement/summary-spec.en.md) (`summary`)
+* [Date of involvement](vulnerabilities/vulnerability/involvements/involvement/date-spec.en.md) (`date`)
+* [Summary](vulnerabilities/vulnerability/involvements/involvement/summary-spec.en.md) (`summary`)
 
 is a container that allows the document producers to comment on the level of involvement (or engagement) of themselves (or third parties) in the vulnerability identification, scoping, and remediation process.
 It can also be used to convey the disclosure timeline. The ordered tuple of the values of `party` and `date` (if present) SHALL be unique within `involvements`.

--- a/docs/user/vulnerabilities/vulnerability/involvements/involvement/party-spec.en.md
+++ b/docs/user/vulnerabilities/vulnerability/involvements/involvement/party-spec.en.md
@@ -9,4 +9,4 @@ Party category (`party`) of value type `string` and `enum` defines the category 
 * `vendor`
 
 These values follow the same definitions as given for the
-[publisher category](../../../../document/publisher/category-spec.en.md).
+[publisher category](document/publisher/category-spec.en.md).

--- a/docs/user/vulnerabilities/vulnerability/notes-spec.en.md
+++ b/docs/user/vulnerabilities/vulnerability/notes-spec.en.md
@@ -8,4 +8,4 @@ Vulnerability notes (`notes`) of value type Notes Type (`notes_t`) holds notes a
 }
 ```
 
-[Specification of Notes Type](../../types/notes-spec.en.md)
+[Specification of Notes Type](types/notes-spec.en.md)

--- a/docs/user/vulnerabilities/vulnerability/product_status-spec.en.md
+++ b/docs/user/vulnerabilities/vulnerability/product_status-spec.en.md
@@ -3,14 +3,14 @@
 Product status (`product_status`) of value type `object` with 1 or more properties contains different lists of product_ids which provide details on the status of the referenced product related to the current vulnerability.
 The eight defined properties are
 
-* [First affected](product_status/first_affected-spec.en.md) (`first_affected`)
-* [First fixed](product_status/first_fixed-spec.en.md) (`first_fixed`)
-* [Fixed](product_status/fixed-spec.en.md) (`fixed`)
-* [Known affected](product_status/known_affected-spec.en.md) (`known_affected`)
-* [Known not affected](product_status/known_not_affected-spec.en.md) (`known_not_affected`)
-* [Last affected](product_status/last_affected-spec.en.md) (`last_affected`)
-* [Recommended](product_status/recommended-spec.en.md) (`recommended`)
-* [Under investigation](product_status/under_investigation-spec.en.md) (`under_investigation`)
+* [First affected](vulnerabilities/vulnerability/product_status/first_affected-spec.en.md) (`first_affected`)
+* [First fixed](vulnerabilities/vulnerability/product_status/first_fixed-spec.en.md) (`first_fixed`)
+* [Fixed](vulnerabilities/vulnerability/product_status/fixed-spec.en.md) (`fixed`)
+* [Known affected](vulnerabilities/vulnerability/product_status/known_affected-spec.en.md) (`known_affected`)
+* [Known not affected](vulnerabilities/vulnerability/product_status/known_not_affected-spec.en.md) (`known_not_affected`)
+* [Last affected](vulnerabilities/vulnerability/product_status/last_affected-spec.en.md) (`last_affected`)
+* [Recommended](vulnerabilities/vulnerability/product_status/recommended-spec.en.md) (`recommended`)
+* [Under investigation](vulnerabilities/vulnerability/product_status/under_investigation-spec.en.md) (`under_investigation`)
 
 are all of value type Products (`products_t`).
 

--- a/docs/user/vulnerabilities/vulnerability/product_status/first_affected-spec.en.md
+++ b/docs/user/vulnerabilities/vulnerability/product_status/first_affected-spec.en.md
@@ -2,4 +2,4 @@
 
 First affected (`first_affected`) of value type Products (`products_t`) represents that these are the first versions of the releases known to be affected by the vulnerability.
 
-[Specification of Products Type](../../../types/products-spec.en.md)
+[Specification of Products Type](types/products-spec.en.md)

--- a/docs/user/vulnerabilities/vulnerability/product_status/first_fixed-spec.en.md
+++ b/docs/user/vulnerabilities/vulnerability/product_status/first_fixed-spec.en.md
@@ -2,4 +2,4 @@
 
 First fixed (`first_fixed`) of value type Products (`products_t`) represents that these versions contain the first fix for the vulnerability but may not be the recommended fixed versions.
 
-[Specification of Products Type](../../../types/products-spec.en.md)
+[Specification of Products Type](types/products-spec.en.md)

--- a/docs/user/vulnerabilities/vulnerability/product_status/fixed-spec.en.md
+++ b/docs/user/vulnerabilities/vulnerability/product_status/fixed-spec.en.md
@@ -2,4 +2,4 @@
 
 Fixed (`fixed`) of value type Products (`products_t`) represents that these versions contain a fix for the vulnerability but may not be the recommended fixed versions.
 
-[Specification of Products Type](../../../types/products-spec.en.md)
+[Specification of Products Type](types/products-spec.en.md)

--- a/docs/user/vulnerabilities/vulnerability/product_status/known_affected-spec.en.md
+++ b/docs/user/vulnerabilities/vulnerability/product_status/known_affected-spec.en.md
@@ -7,4 +7,4 @@ Actions are recommended to remediate or address this vulnerability.
 > to patch or apply defense-in-depth measures. See `/vulnerabilities[]/remediations`, `/vulnerabilities[]/notes` and
 > `/vulnerabilities[]/threats` for more details.
 
-[Specification of Products Type](../../../types/products-spec.en.md)
+[Specification of Products Type](types/products-spec.en.md)

--- a/docs/user/vulnerabilities/vulnerability/product_status/known_not_affected-spec.en.md
+++ b/docs/user/vulnerabilities/vulnerability/product_status/known_not_affected-spec.en.md
@@ -6,4 +6,4 @@ No remediation is required regarding this vulnerability.
 > This could for instance be because the code referenced in the vulnerability is not present, not exposed, compensating
 > controls exist, or other factors. See /vulnerabilities[]/threats in category impact for more details.
 
-[Specification of Products Type](../../../types/products-spec.en.md)
+[Specification of Products Type](types/products-spec.en.md)

--- a/docs/user/vulnerabilities/vulnerability/product_status/last_affected-spec.en.md
+++ b/docs/user/vulnerabilities/vulnerability/product_status/last_affected-spec.en.md
@@ -3,4 +3,4 @@
 Last affected (`last_affected`) of value type Products (`products_t`) represents that these are the last versions in a release train known to be affected by the vulnerability.
 Subsequently released versions would contain a fix for the vulnerability.
 
-[Specification of Products Type](../../../types/products-spec.en.md)
+[Specification of Products Type](types/products-spec.en.md)

--- a/docs/user/vulnerabilities/vulnerability/product_status/recommended-spec.en.md
+++ b/docs/user/vulnerabilities/vulnerability/product_status/recommended-spec.en.md
@@ -2,4 +2,4 @@
 
 Recommended (`recommended`) of value type Products (`products_t`) represents that these versions have a fix for the vulnerability and are the vendor-recommended versions for fixing the vulnerability.
 
-[Specification of Products Type](../../../types/products-spec.en.md)
+[Specification of Products Type](types/products-spec.en.md)

--- a/docs/user/vulnerabilities/vulnerability/product_status/under_investigation-spec.en.md
+++ b/docs/user/vulnerabilities/vulnerability/product_status/under_investigation-spec.en.md
@@ -3,4 +3,4 @@
 Under investigation (`under_investigation`) of value type Products (`products_t`) represents that it is not known yet whether these versions are or are not affected by the vulnerability.
 However, it is still under investigation - the result will be provided in a later release of the document.
 
-[Specification of Products Type](../../../types/products-spec.en.md)
+[Specification of Products Type](types/products-spec.en.md)

--- a/docs/user/vulnerabilities/vulnerability/references-spec.en.md
+++ b/docs/user/vulnerabilities/vulnerability/references-spec.en.md
@@ -8,4 +8,4 @@ Vulnerability references (`references`) of value type References Type (`referenc
 }
 ```
 
-[Specification of References Type](../../types/references-spec.en.md)
+[Specification of References Type](types/references-spec.en.md)

--- a/docs/user/vulnerabilities/vulnerability/remediations-spec.en.md
+++ b/docs/user/vulnerabilities/vulnerability/remediations-spec.en.md
@@ -11,4 +11,4 @@ List of remediations (`remediations`) of value type `array` with 1 or more Remed
 }
 ```
 
-[Specification of Remediation items](remediations/remediation-spec.en.md)
+[Specification of Remediation items](vulnerabilities/vulnerability/remediations/remediation-spec.en.md)

--- a/docs/user/vulnerabilities/vulnerability/remediations/remediation-spec.en.md
+++ b/docs/user/vulnerabilities/vulnerability/remediations/remediation-spec.en.md
@@ -2,19 +2,19 @@
 
 Every Remediation item of value type `object` with the 2 mandatory properties
 
-* [Category](remediation/category-spec.en.md) (`category`)
-* [Details](remediation/details-spec.en.md) (`details`)
+* [Category](vulnerabilities/vulnerability/remediations/remediation/category-spec.en.md) (`category`)
+* [Details](vulnerabilities/vulnerability/remediations/remediation/details-spec.en.md) (`details`)
 
 specifies details on how to handle (and presumably, fix) a vulnerability.
 
 In addition, any Remediation MAY expose the six optional properties
 
-* [Date](remediation/date-spec.en.md) (`date`)
-* [Entitlements](remediation/entitlements-spec.en.md) (`entitlements`)
-* [Group IDs](remediation/group_ids-spec.en.md) (`group_ids`)
-* [Product IDs](remediation/product_ids-spec.en.md) (`product_ids`)
-* [Restart required](remediation/restart_required-spec.en.md) (`restart_required`)
-* [URL](remediation/url-spec.en.md) (`url`)
+* [Date](vulnerabilities/vulnerability/remediations/remediation/date-spec.en.md) (`date`)
+* [Entitlements](vulnerabilities/vulnerability/remediations/remediation/entitlements-spec.en.md) (`entitlements`)
+* [Group IDs](vulnerabilities/vulnerability/remediations/remediation/group_ids-spec.en.md) (`group_ids`)
+* [Product IDs](vulnerabilities/vulnerability/remediations/remediation/product_ids-spec.en.md) (`product_ids`)
+* [Restart required](vulnerabilities/vulnerability/remediations/remediation/restart_required-spec.en.md) (`restart_required`)
+* [URL](vulnerabilities/vulnerability/remediations/remediation/url-spec.en.md) (`url`)
 
 ```javascript
 "properties": {

--- a/docs/user/vulnerabilities/vulnerability/remediations/remediation/entitlements-spec.en.md
+++ b/docs/user/vulnerabilities/vulnerability/remediations/remediation/entitlements-spec.en.md
@@ -11,4 +11,4 @@ List of entitlements (`entitlements`) of value type `array` with 1 or more items
 }
 ```
 
-[Specification of Entitlement items](entitlements/entitlement-spec.en.md)
+[Specification of Entitlement items](vulnerabilities/vulnerability/remediations/remediation/entitlements/entitlement-spec.en.md)

--- a/docs/user/vulnerabilities/vulnerability/remediations/remediation/group_ids-spec.en.md
+++ b/docs/user/vulnerabilities/vulnerability/remediations/remediation/group_ids-spec.en.md
@@ -2,4 +2,4 @@
 
 Group IDs (group_ids) are of value type Product Groups (product_groups_t).
 
-[Specification of Product Groups Type](../../../../types/product_groups-spec.en.md)
+[Specification of Product Groups Type](types/product_groups-spec.en.md)

--- a/docs/user/vulnerabilities/vulnerability/remediations/remediation/product_ids-spec.en.md
+++ b/docs/user/vulnerabilities/vulnerability/remediations/remediation/product_ids-spec.en.md
@@ -2,4 +2,4 @@
 
 Product IDs (`product_ids`) are of value type Products (`products_t`).
 
-[Specification of Products Type](../../../../types/products-spec.en.md)
+[Specification of Products Type](types/products-spec.en.md)

--- a/docs/user/vulnerabilities/vulnerability/remediations/remediation/restart_required-spec.en.md
+++ b/docs/user/vulnerabilities/vulnerability/remediations/remediation/restart_required-spec.en.md
@@ -2,11 +2,11 @@
 
 Restart required by remediation (`restart_required`) of value type `object` with the 1 mandatory property
 
-* [Category](restart_required/category-spec.en.md) (`category`)
+* [Category](vulnerabilities/vulnerability/remediations/remediation/restart_required/category-spec.en.md) (`category`)
 
 and the optional property
 
-* [Details](restart_required/details-spec.en.md) (`details`)
+* [Details](vulnerabilities/vulnerability/remediations/remediation/restart_required/details-spec.en.md) (`details`)
 
 provides information on category of restart is required by this remediation to become effective.
 

--- a/docs/user/vulnerabilities/vulnerability/scores-spec.en.md
+++ b/docs/user/vulnerabilities/vulnerability/scores-spec.en.md
@@ -11,4 +11,4 @@ List of scores (`scores`) of value type `array` with 1 or more items of type sco
 }
 ```
 
-[Specification of Score items](scores/score-spec.en.md)
+[Specification of Score items](vulnerabilities/vulnerability/scores/score-spec.en.md)

--- a/docs/user/vulnerabilities/vulnerability/scores/score-spec.en.md
+++ b/docs/user/vulnerabilities/vulnerability/scores/score-spec.en.md
@@ -2,12 +2,12 @@
 
 Value type of every such Score item is `object` with the mandatory property
 
-* [Products](score/products-spec.en.md) (`products`)
+* [Products](vulnerabilities/vulnerability/scores/score/products-spec.en.md) (`products`)
 
 and the optional properties
 
-* [CVSS v2](score/cvss_v2-spec.en.md) `cvss_v2`
-* [CVSS v3](score/cvss_v3-spec.en.md) `cvss_v3`
+* [CVSS v2](vulnerabilities/vulnerability/scores/score/cvss_v2-spec.en.md) `cvss_v2`
+* [CVSS v3](vulnerabilities/vulnerability/scores/score/cvss_v3-spec.en.md) `cvss_v3`
 
 specifies information about (at least one) score of the vulnerability and for which products the given value applies.
 Each Score item has at least 2 properties.

--- a/docs/user/vulnerabilities/vulnerability/scores/score/products-spec.en.md
+++ b/docs/user/vulnerabilities/vulnerability/scores/score/products-spec.en.md
@@ -3,4 +3,4 @@
 Product IDs (`products`) of value type `products_t` with 1 or more items indicates for which products the given scores apply.
 A score object SHOULD reflect the associated product's status (for example, a fixed product no longer contains a vulnerability and should have a CVSS score of 0, or simply no score listed; the known affected versions of that product can list the vulnerability score as it applies to them).
 
-[Specification of Products Type](../../../../types/products-spec.en.md)
+[Specification of Products Type](types/products-spec.en.md)

--- a/docs/user/vulnerabilities/vulnerability/threats-spec.en.md
+++ b/docs/user/vulnerabilities/vulnerability/threats-spec.en.md
@@ -11,4 +11,4 @@ List of threats (`threats`) of value type `array` with 1 or more items of value 
 }
 ```
 
-[Specification of Threat items](threats/threat-spec.en.md)
+[Specification of Threat items](vulnerabilities/vulnerability/threats/threat-spec.en.md)

--- a/docs/user/vulnerabilities/vulnerability/threats/threat-spec.en.md
+++ b/docs/user/vulnerabilities/vulnerability/threats/threat-spec.en.md
@@ -2,15 +2,15 @@
 
 Every Threat item of value type `object` with the two mandatory properties
 
-* [Category](threat/category-spec.en.md) (`category`)
-* [Details](threat/details-spec.en.md) (`details`)
+* [Category](vulnerabilities/vulnerability/threats/threat/category-spec.en.md) (`category`)
+* [Details](vulnerabilities/vulnerability/threats/threat/details-spec.en.md) (`details`)
 
 contains the vulnerability kinetic information. This information can change as the vulnerability ages and new information becomes available.
 In addition, any Threat item MAY expose the three optional properties
 
-* [Date](threat/date-spec.en.md) (`date`)
-* [Group IDs](threat/group_ids-spec.en.md) (`group_ids`),
-* [Product IDs](threat/product_ids-spec.en.md) (`product_ids`)
+* [Date](vulnerabilities/vulnerability/threats/threat/date-spec.en.md) (`date`)
+* [Group IDs](vulnerabilities/vulnerability/threats/threat/group_ids-spec.en.md) (`group_ids`),
+* [Product IDs](vulnerabilities/vulnerability/threats/threat/product_ids-spec.en.md) (`product_ids`)
 
 ```javascript
 "properties": {

--- a/docs/user/vulnerabilities/vulnerability/threats/threat/group_ids-spec.en.md
+++ b/docs/user/vulnerabilities/vulnerability/threats/threat/group_ids-spec.en.md
@@ -2,4 +2,4 @@
 
 Group IDs (`group_ids`) are of value type Product Groups (`product_groups_t`).
 
-[Specification of Product Groups Type](../../../../types/product_groups-spec.en.md)
+[Specification of Product Groups Type](types/product_groups-spec.en.md)

--- a/docs/user/vulnerabilities/vulnerability/threats/threat/product_ids-spec.en.md
+++ b/docs/user/vulnerabilities/vulnerability/threats/threat/product_ids-spec.en.md
@@ -2,4 +2,4 @@
 
 Product IDs (`product_ids`) are of value type Products (`products_t`).
 
-[Specification of Products Type](../../../../types/products-spec.en.md)
+[Specification of Products Type](types/products-spec.en.md)


### PR DESCRIPTION
This adds a script to merge markdown files ordered in a hierarchic directory structure to a larger markdown file.

The script was/is developed and tested in an internal repository.

To merge all markdown files to a larger one, run

```sh
cd docs
python md_merge.py -i user -o out -n user-documentation.md --paths-relative-to-input-dir
```

For some more information on arguments run

```
python md_merge.py --help
```

The script was developed and tested with python 3.9.7.

Additionally, I switched from links relative to a files location to links relative to the `docs/user` dir as this will simplify dealing with those links in the frontend of secvisogram 2.0 later on. The script would be able to deal with both versions, though, see the argument `--paths-relative-to-input-dir`.