### PR TITLE
chore: add os agnostic script for development

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "test": "eslint . && cypress run",
     "build": "node scripts/build.js",
-    "dev": "webpack serve --mode development --port=$npm_config_port"
+    "dev": "node scripts/dev.js"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.36",

--- a/app/scripts/dev.js
+++ b/app/scripts/dev.js
@@ -1,0 +1,13 @@
+import { spawn } from 'child_process'
+import * as os from 'os';
+
+const command = /^win/.test(os.platform())
+  ? `webpack serve --mode development --port=%npm_config_port%`
+  : `webpack serve --mode development --port=$npm_config_port`
+
+spawn(command, {
+  stdio: 'inherit',
+  shell: true,
+}).on('exit', (code) => {
+  process.exit(code ?? 0)
+})


### PR DESCRIPTION
Using a script to run os specific commands, since reading variables is different on Win/linux.