### PR TITLE
fix(revision_history): correct variable name "legacy_version"

### DIFF
--- a/app/lib/SecvisogramPage/View/FormEditorTab/Document/Tracking/RevisionHistory.js
+++ b/app/lib/SecvisogramPage/View/FormEditorTab/Document/Tracking/RevisionHistory.js
@@ -39,7 +39,7 @@ export default function RevisionHistory(props) {
                 description="The date of the revision entry"
               />
               <TextAreaAttribute
-                {...revisionHistoryItemProps('legacy_revision')}
+                {...revisionHistoryItemProps('legacy_version')}
                 label="Legacy version of the revision"
                 description="Contains the version string used in an existing document with the same content."
                 deletable


### PR DESCRIPTION
@domachine / @cloeser: Does that also affect the Wizard?
addresses part of #287 