### PR TITLE
fix: copy revision history before sorting

### DIFF
--- a/app/lib/app/SecvisogramPage/View.js
+++ b/app/lib/app/SecvisogramPage/View.js
@@ -328,17 +328,15 @@ function View({
     let prefilledSummary = ''
     let prefilledLegacyVersion = ''
     if (
-      tracking &&
-      tracking.version &&
-      tracking.revision_history &&
-      tracking.revision_history.length
+      tracking?.revision_history?.length
     ) {
       const majorVersion =
         typeof tracking.version === 'string'
           ? parseInt(tracking.version.split('.')[0])
           : tracking.version
       if (majorVersion >= 1) {
-        const latestRevisionHistoryItem = tracking?.revision_history.sort(
+        const revisionHistoryCopy = [...tracking.revision_history]
+        const latestRevisionHistoryItem = revisionHistoryCopy.sort(
           (/** @type {{date: string}} */ a, /** @type {{date: string}} */ z) =>
             new Date(z.date).getTime() - new Date(a.date).getTime()
         )[0]

--- a/app/lib/app/SecvisogramPage/View.js
+++ b/app/lib/app/SecvisogramPage/View.js
@@ -327,9 +327,7 @@ function View({
     const tracking = formValues.doc.document.tracking
     let prefilledSummary = ''
     let prefilledLegacyVersion = ''
-    if (
-      tracking?.revision_history?.length
-    ) {
+    if (tracking?.version && tracking.revision_history?.length) {
       const majorVersion =
         typeof tracking.version === 'string'
           ? parseInt(tracking.version.split('.')[0])


### PR DESCRIPTION
This fix makes sure that prefilling the summary does not change the order of revision history items in the document.