### PR TITLE
Feat/disable fields

### DIFF
--- a/app/lib/app/SecvisogramPage/View/WizardTab/editors/GenericEditor.js
+++ b/app/lib/app/SecvisogramPage/View/WizardTab/editors/GenericEditor.js
@@ -123,6 +123,7 @@ export default function Editor({ parentProperty, property, instancePath }) {
           value={value || ''}
           property={property}
           disabled={disabled}
+          disableClearable={true}
         />
       )
     } else if (uiType === 'STRING_WITH_OPTIONS') {
@@ -136,6 +137,7 @@ export default function Editor({ parentProperty, property, instancePath }) {
           value={value || ''}
           property={property}
           disabled={disabled}
+          disableClearable={true}
         />
       )
     } else if (uiType === 'STRING_MULTI_LINE') {

--- a/app/lib/app/SecvisogramPage/View/WizardTab/editors/GenericEditor.js
+++ b/app/lib/app/SecvisogramPage/View/WizardTab/editors/GenericEditor.js
@@ -12,6 +12,7 @@ import ObjectEditor from './GenericEditor/ObjectEditor.js'
 import CVSS2Editor from './GenericEditor/CVSS2Editor.js'
 import CVSSV3Attribute from './GenericEditor/Attributes/CVSS3Attribute.js'
 import AppConfigContext from '../../../../shared/context/AppConfigContext.js'
+import UserInfoContext from '../../../../shared/context/UserInfoContext.js'
 
 /**
  * utility function to get the color of circles identifying errors
@@ -40,15 +41,17 @@ export function getErrorTextColor(errors) {
  */
 export default function Editor({ parentProperty, property, instancePath }) {
   const { loginAvailable } = React.useContext(AppConfigContext)
+  const userInfo = React.useContext(UserInfoContext)
 
   const { doc, collectIds } = React.useContext(DocumentEditorContext)
 
   const uiType = property.metaData?.uiType
   const label = property.title || property.metaData?.title || 'missing title'
 
-  const disabled = loginAvailable
-    ? property.metaData?.disable?.ifServerMode || false
-    : property.metaData?.disable?.ifStandaloneMode || false
+  const disabled =
+    loginAvailable && userInfo
+      ? property.metaData?.disable?.ifServerMode || false
+      : property.metaData?.disable?.ifStandaloneMode || false
 
   const description =
     property.description ||

--- a/app/lib/app/SecvisogramPage/View/WizardTab/editors/GenericEditor.js
+++ b/app/lib/app/SecvisogramPage/View/WizardTab/editors/GenericEditor.js
@@ -11,6 +11,7 @@ import TextAttribute from './GenericEditor/Attributes/TextAttribute.js'
 import ObjectEditor from './GenericEditor/ObjectEditor.js'
 import CVSS2Editor from './GenericEditor/CVSS2Editor.js'
 import CVSSV3Attribute from './GenericEditor/Attributes/CVSS3Attribute.js'
+import AppConfigContext from '../../../../shared/context/AppConfigContext.js'
 
 /**
  * utility function to get the color of circles identifying errors
@@ -38,10 +39,17 @@ export function getErrorTextColor(errors) {
  * @param {string[]} props.instancePath
  */
 export default function Editor({ parentProperty, property, instancePath }) {
+  const { loginAvailable } = React.useContext(AppConfigContext)
+
   const { doc, collectIds } = React.useContext(DocumentEditorContext)
 
   const uiType = property.metaData?.uiType
   const label = property.title || property.metaData?.title || 'missing title'
+
+  const disabled = loginAvailable
+    ? property.metaData?.disable?.ifServerMode || false
+    : property.metaData?.disable?.ifStandaloneMode || false
+
   const description =
     property.description ||
     property.metaData?.description ||
@@ -61,6 +69,7 @@ export default function Editor({ parentProperty, property, instancePath }) {
           description={description}
           property={property}
           instancePath={instancePath}
+          disabled={disabled}
         />
       )
     } else if (uiType === 'OBJECT_CVSS_2') {
@@ -80,6 +89,7 @@ export default function Editor({ parentProperty, property, instancePath }) {
           instancePath={instancePath}
           value={/** @type {{[key: string]: string | number }} */ (value)}
           property={property}
+          disabled={disabled}
         />
       )
     }
@@ -99,6 +109,7 @@ export default function Editor({ parentProperty, property, instancePath }) {
           instancePath={instancePath}
           value={value || ''}
           property={property}
+          disabled={disabled}
         />
       )
     } else if (uiType === 'STRING_ENUM') {
@@ -111,6 +122,7 @@ export default function Editor({ parentProperty, property, instancePath }) {
           instancePath={instancePath}
           value={value || ''}
           property={property}
+          disabled={disabled}
         />
       )
     } else if (uiType === 'STRING_WITH_OPTIONS') {
@@ -123,6 +135,7 @@ export default function Editor({ parentProperty, property, instancePath }) {
           instancePath={instancePath}
           value={value || ''}
           property={property}
+          disabled={disabled}
         />
       )
     } else if (uiType === 'STRING_MULTI_LINE') {
@@ -135,6 +148,7 @@ export default function Editor({ parentProperty, property, instancePath }) {
           instancePath={instancePath}
           value={value || ''}
           property={property}
+          disabled={disabled}
         />
       )
     } else if (uiType === 'STRING_PRODUCT_ID') {
@@ -146,6 +160,7 @@ export default function Editor({ parentProperty, property, instancePath }) {
           value={value || ''}
           onCollectIds={collectIds['productIds']}
           property={property}
+          disabled={disabled}
         />
       )
     } else if (uiType === 'STRING_GROUP_ID') {
@@ -157,6 +172,7 @@ export default function Editor({ parentProperty, property, instancePath }) {
           value={value || ''}
           onCollectIds={collectIds['groupIds']}
           property={property}
+          disabled={disabled}
         />
       )
     } else if (uiType === 'STRING_URI') {
@@ -171,6 +187,7 @@ export default function Editor({ parentProperty, property, instancePath }) {
           instancePath={instancePath}
           value={value || ''}
           property={property}
+          disabled={disabled}
         />
       )
     } else {
@@ -184,6 +201,7 @@ export default function Editor({ parentProperty, property, instancePath }) {
           instancePath={instancePath}
           value={value || ''}
           property={property}
+          disabled={disabled}
         />
       )
     }
@@ -194,6 +212,7 @@ export default function Editor({ parentProperty, property, instancePath }) {
         instancePath={instancePath}
         label={label}
         property={property}
+        disabled={false}
       >
         {typeof value === 'number' ? String(value) : ''}
       </Attribute>

--- a/app/lib/app/SecvisogramPage/View/WizardTab/editors/GenericEditor/Attributes/CVSS3Attribute.js
+++ b/app/lib/app/SecvisogramPage/View/WizardTab/editors/GenericEditor/Attributes/CVSS3Attribute.js
@@ -55,8 +55,8 @@ export default function CVSSV3Attribute({
     [outerDocumentEditor, updateDoc, instancePath, doc, cvssVector]
   )
 
-  /** @type {(childName: string, options: string[]) => any} */
-  const dropdownFor = (childName, options) => {
+  /** @type {(childName: string, options: string[], disableClearable: boolean) => any} */
+  function dropdownFor(childName, options, disableClearable = true) {
     return (
       <DropdownAttribute
         label={childName.charAt(0).toUpperCase() + childName.substring(1)}
@@ -67,6 +67,7 @@ export default function CVSSV3Attribute({
         value={(value || {})[childName] || ''}
         property={property}
         disabled={disabled}
+        disableClearable={disableClearable}
       />
     )
   }
@@ -138,29 +139,33 @@ export default function CVSSV3Attribute({
           >
             {value?.baseSeverity || ''}
           </Attribute>
-          {dropdownFor('exploitCodeMaturity', [
-            'UNPROVEN',
-            'PROOF_OF_CONCEPT',
-            'FUNCTIONAL',
-            'HIGH',
-            'NOT_DEFINED',
-            '',
-          ])}
-          {dropdownFor('remediationLevel', [
-            'OFFICIAL_FIX',
-            'TEMPORARY_FIX',
-            'WORKAROUND',
-            'UNAVAILABLE',
-            'NOT_DEFINED',
-            '',
-          ])}
-          {dropdownFor('reportConfidence', [
-            'UNKNOWN',
-            'REASONABLE',
-            'CONFIRMED',
-            'NOT_DEFINED',
-            '',
-          ])}
+          {dropdownFor(
+            'exploitCodeMaturity',
+            [
+              'UNPROVEN',
+              'PROOF_OF_CONCEPT',
+              'FUNCTIONAL',
+              'HIGH',
+              'NOT_DEFINED',
+            ],
+            false
+          )}
+          {dropdownFor(
+            'remediationLevel',
+            [
+              'OFFICIAL_FIX',
+              'TEMPORARY_FIX',
+              'WORKAROUND',
+              'UNAVAILABLE',
+              'NOT_DEFINED',
+            ],
+            false
+          )}
+          {dropdownFor(
+            'reportConfidence',
+            ['UNKNOWN', 'REASONABLE', 'CONFIRMED', 'NOT_DEFINED'],
+            false
+          )}
           <Attribute
             label={'TemporalScore'}
             description={'The CVSS Temporal Score'}
@@ -181,81 +186,61 @@ export default function CVSSV3Attribute({
           >
             {value?.temporalSeverity || ''}
           </Attribute>
-          {dropdownFor('confidentialityRequirement', [
-            'LOW',
-            'MEDIUM',
-            'HIGH',
-            'NOT_DEFINED',
-            '',
-          ])}
-          {dropdownFor('integrityRequirement', [
-            'LOW',
-            'MEDIUM',
-            'HIGH',
-            'NOT_DEFINED',
-            '',
-          ])}
-          {dropdownFor('availabilityRequirement', [
-            'LOW',
-            'MEDIUM',
-            'HIGH',
-            'NOT_DEFINED',
-            '',
-          ])}
-          {dropdownFor('modifiedAttackVector', [
-            'NETWORK',
-            'ADJACENT_NETWORK',
-            'LOCAL',
-            'PHYSICAL',
-            'NOT_DEFINED',
-            '',
-          ])}
-          {dropdownFor('modifiedAttackComplexity', [
-            'HIGH',
-            'LOW',
-            'NOT_DEFINED',
-            '',
-          ])}
-          {dropdownFor('modifiedPrivilegesRequired', [
-            'NONE',
-            'LOW',
-            'HIGH',
-            'NOT_DEFINED',
-            '',
-          ])}
-          {dropdownFor('modifiedUserInteraction', [
-            'NONE',
-            'REQUIRED',
-            'NOT_DEFINED',
-            '',
-          ])}
-          {dropdownFor('modifiedScope', [
-            'UNCHANGED',
-            'CHANGED',
-            'NOT_DEFINED',
-            '',
-          ])}
-          {dropdownFor('modifiedConfidentialityImpact', [
-            'NONE',
-            'LOW',
-            'HIGH',
-            'NOT_DEFINED',
-            '',
-          ])}
-          {dropdownFor('modifiedIntegrityImpact', [
-            'NONE',
-            'LOW',
-            'HIGH',
-            'NOT_DEFINED',
-            '',
-          ])}
-          {dropdownFor('modifiedAvailabilityImpact', [
-            'NONE',
-            'LOW',
-            'HIGH',
-            'NOT_DEFINED',
-            '',
-          ])}
+          {dropdownFor(
+            'confidentialityRequirement',
+            ['LOW', 'MEDIUM', 'HIGH', 'NOT_DEFINED'],
+            false
+          )}
+          {dropdownFor(
+            'integrityRequirement',
+            ['LOW', 'MEDIUM', 'HIGH', 'NOT_DEFINED'],
+            false
+          )}
+          {dropdownFor(
+            'availabilityRequirement',
+            ['LOW', 'MEDIUM', 'HIGH', 'NOT_DEFINED'],
+            false
+          )}
+          {dropdownFor(
+            'modifiedAttackVector',
+            ['NETWORK', 'ADJACENT_NETWORK', 'LOCAL', 'PHYSICAL', 'NOT_DEFINED'],
+            false
+          )}
+          {dropdownFor(
+            'modifiedAttackComplexity',
+            ['HIGH', 'LOW', 'NOT_DEFINED'],
+            false
+          )}
+          {dropdownFor(
+            'modifiedPrivilegesRequired',
+            ['NONE', 'LOW', 'HIGH', 'NOT_DEFINED'],
+            false
+          )}
+          {dropdownFor(
+            'modifiedUserInteraction',
+            ['NONE', 'REQUIRED', 'NOT_DEFINED'],
+            false
+          )}
+          {dropdownFor(
+            'modifiedScope',
+            ['UNCHANGED', 'CHANGED', 'NOT_DEFINED'],
+            false
+          )}
+          {dropdownFor(
+            'modifiedConfidentialityImpact',
+            ['NONE', 'LOW', 'HIGH', 'NOT_DEFINED'],
+            false
+          )}
+          {dropdownFor(
+            'modifiedIntegrityImpact',
+            ['NONE', 'LOW', 'HIGH', 'NOT_DEFINED'],
+            false
+          )}
+          {dropdownFor(
+            'modifiedAvailabilityImpact',
+            ['NONE', 'LOW', 'HIGH', 'NOT_DEFINED'],
+            false
+          )}
           <Attribute
             label={'EnvironmentalScore'}
             description={'The CVSS Environmental Score'}

--- a/app/lib/app/SecvisogramPage/View/WizardTab/editors/GenericEditor/Attributes/CVSS3Attribute.js
+++ b/app/lib/app/SecvisogramPage/View/WizardTab/editors/GenericEditor/Attributes/CVSS3Attribute.js
@@ -13,6 +13,7 @@ import CVSSVector from './CVSS3Attribute/CVSSVector.js'
  *  instancePath: string[]
  *  value: {[key: string]: string | number }
  *  property: import('../../../shared/types').Property
+ *  disabled: boolean
  * }} props
  */
 export default function CVSSV3Attribute({
@@ -21,6 +22,7 @@ export default function CVSSV3Attribute({
   instancePath,
   value,
   property,
+  disabled,
 }) {
   const { doc, updateDoc, ...outerDocumentEditor } = React.useContext(
     DocumentEditorContext
@@ -64,6 +66,7 @@ export default function CVSSV3Attribute({
         instancePath={instancePath.concat([childName])}
         value={(value || {})[childName] || ''}
         property={property}
+        disabled={disabled}
       />
     )
   }
@@ -76,6 +79,7 @@ export default function CVSSV3Attribute({
           description={description}
           instancePath={instancePath}
           property={property}
+          disabled={disabled}
         >
           {dropdownFor('version', ['3.0', '3.1'])}
           <TextAttribute
@@ -87,6 +91,7 @@ export default function CVSSV3Attribute({
             instancePath={instancePath.concat(['vectorString'])}
             value={value?.vectorString || ''}
             property={property}
+            disabled={disabled}
           />
           {canBeUpgraded ? (
             <div className="mb-2">
@@ -118,6 +123,7 @@ export default function CVSSV3Attribute({
             description={'The CVSS Base Score'}
             instancePath={instancePath.concat(['baseScore'])}
             property={property}
+            disabled={false}
           >
             {typeof value?.baseScore === 'number'
               ? String(value.baseScore)
@@ -128,6 +134,7 @@ export default function CVSSV3Attribute({
             description={'The CVSS Base Severity'}
             instancePath={instancePath.concat(['baseSeverity'])}
             property={property}
+            disabled={false}
           >
             {value?.baseSeverity || ''}
           </Attribute>
@@ -159,6 +166,7 @@ export default function CVSSV3Attribute({
             description={'The CVSS Temporal Score'}
             instancePath={instancePath.concat(['temporalScore'])}
             property={property}
+            disabled={false}
           >
             {typeof value?.temporalScore === 'number'
               ? String(value.temporalScore)
@@ -169,6 +177,7 @@ export default function CVSSV3Attribute({
             description={'The CVSS Temporal Severity'}
             instancePath={instancePath.concat(['temporalSeverity'])}
             property={property}
+            disabled={false}
           >
             {value?.temporalSeverity || ''}
           </Attribute>
@@ -252,6 +261,7 @@ export default function CVSSV3Attribute({
             description={'The CVSS Environmental Score'}
             instancePath={instancePath.concat(['environmentalScore'])}
             property={property}
+            disabled={false}
           >
             {typeof value?.environmentalScore === 'number'
               ? String(value.environmentalScore)
@@ -262,6 +272,7 @@ export default function CVSSV3Attribute({
             description={'The CVSS Environmental Severity'}
             instancePath={instancePath.concat(['environmentalSeverity'])}
             property={property}
+            disabled={false}
           >
             {value?.environmentalSeverity || ''}
           </Attribute>

--- a/app/lib/app/SecvisogramPage/View/WizardTab/editors/GenericEditor/Attributes/CweAttribute.js
+++ b/app/lib/app/SecvisogramPage/View/WizardTab/editors/GenericEditor/Attributes/CweAttribute.js
@@ -40,6 +40,7 @@ const getChildProps = (
  *  label: string
  *  description: string
  *  instancePath: string[]
+ *  disabled: boolean
  *  property: import('../../../shared/types').Property
  * }} props
  */
@@ -48,6 +49,7 @@ export default function CweAttribute({
   description,
   property,
   instancePath,
+  disabled,
 }) {
   const { doc, updateDoc, pruneEmpty } = React.useContext(DocumentEditorContext)
 
@@ -70,6 +72,7 @@ export default function CweAttribute({
       description={description}
       instancePath={instancePath}
       property={property}
+      disabled={disabled}
     >
       <CwecId
         label={idProperties?.title || ''}
@@ -78,6 +81,7 @@ export default function CweAttribute({
         value={idValue}
         onChange={onChange}
         property={property}
+        disabled={disabled}
       />
       <CwecName
         label={nameProperties?.title || ''}
@@ -86,6 +90,7 @@ export default function CweAttribute({
         value={nameValue}
         onChange={onChange}
         property={property}
+        disabled={disabled}
       />
     </Attribute>
   )
@@ -116,6 +121,7 @@ function useCwecMatch(term) {
  *  value: unknown
  *  onChange({}): void
  *  property: import('../../../shared/types').Property
+ *  disabled: boolean
  * }} props
  */
 function CwecId({
@@ -125,6 +131,7 @@ function CwecId({
   value,
   onChange,
   property,
+  disabled,
 }) {
   const [inputValue, setInputValue] = React.useState(
     /** @type string */ (value)
@@ -155,6 +162,7 @@ function CwecId({
       description={description}
       instancePath={instancePath}
       property={property}
+      disabled={disabled}
     >
       <div className="max-w-md flex">
         <div className="w-full">
@@ -166,6 +174,7 @@ function CwecId({
               placeholder="^CWE-[1-9]\d{0,5}$"
               required={true}
               onChange={handleChange}
+              disabled={disabled}
             />
             {results && (
               <ComboboxPopover className="shadow-popup">
@@ -199,6 +208,7 @@ function CwecId({
  *  value: unknown
  *  onChange({}): void
  *  property: import('../../../shared/types').Property
+ *  disabled: boolean
  * }} props
  */
 function CwecName({
@@ -208,6 +218,7 @@ function CwecName({
   value,
   onChange,
   property,
+  disabled,
 }) {
   const [inputValue, setInputValue] = React.useState(
     /** @type string */ (value)
@@ -239,6 +250,7 @@ function CwecName({
       description={description}
       instancePath={instancePath}
       property={property}
+      disabled={disabled}
     >
       <div className="max-w-md flex">
         <div className="w-full">
@@ -249,6 +261,7 @@ function CwecName({
               placeholder="Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting') ..."
               required={true}
               onChange={handleChange}
+              disabled={disabled}
             />
             {results && (
               <ComboboxPopover className="shadow-popup">

--- a/app/lib/app/SecvisogramPage/View/WizardTab/editors/GenericEditor/Attributes/DateAttribute.js
+++ b/app/lib/app/SecvisogramPage/View/WizardTab/editors/GenericEditor/Attributes/DateAttribute.js
@@ -7,22 +7,22 @@ import DocumentEditorContext from '../../../../shared/DocumentEditorContext.js'
  * @param {{
  *  label: string
  *  description: string
- *  readOnly?: boolean
  *  required?: boolean
  *  instancePath: string[]
  *  value: unknown
- *   property: import('../../../shared/types').Property
+ *  property: import('../../../shared/types').Property
+ *  disabled: boolean
  * }} props
  */
 export default function DateAttribute({
   required = true,
-  readOnly = false,
   value,
+  disabled,
   ...props
 }) {
   const { updateDoc, pruneEmpty } = React.useContext(DocumentEditorContext)
   return (
-    <Attribute {...props}>
+    <Attribute disabled={disabled} {...props}>
       <div className="max-w-md flex items-center justify-center">
         <div className="w-full">
           <DatePicker
@@ -36,7 +36,7 @@ export default function DateAttribute({
                 pruneEmpty()
               }
             }}
-            readOnly={readOnly}
+            readOnly={disabled}
           />
         </div>
       </div>

--- a/app/lib/app/SecvisogramPage/View/WizardTab/editors/GenericEditor/Attributes/DropdownAttribute.js
+++ b/app/lib/app/SecvisogramPage/View/WizardTab/editors/GenericEditor/Attributes/DropdownAttribute.js
@@ -14,6 +14,7 @@ import Attribute from './shared/Attribute.js'
  *  value: unknown
  *  property: import('../../../shared/types').Property
  *  disabled: boolean
+ *  disableClearable: boolean
  * }} props
  */
 export default function DropdownAttribute({
@@ -21,6 +22,7 @@ export default function DropdownAttribute({
   isEnum,
   value,
   disabled,
+  disableClearable = true,
   ...props
 }) {
   const { updateDoc, pruneEmpty } = React.useContext(DocumentEditorContext)
@@ -30,7 +32,7 @@ export default function DropdownAttribute({
       <div className="max-w-md flex">
         <div className="w-full">
           <Autocomplete
-            disableClearable
+            disableClearable={disableClearable}
             options={options}
             freeSolo={!isEnum}
             value={value}

--- a/app/lib/app/SecvisogramPage/View/WizardTab/editors/GenericEditor/Attributes/DropdownAttribute.js
+++ b/app/lib/app/SecvisogramPage/View/WizardTab/editors/GenericEditor/Attributes/DropdownAttribute.js
@@ -13,18 +13,20 @@ import Attribute from './shared/Attribute.js'
  *  instancePath: string[]
  *  value: unknown
  *  property: import('../../../shared/types').Property
+ *  disabled: boolean
  * }} props
  */
 export default function DropdownAttribute({
   options,
   isEnum,
   value,
+  disabled,
   ...props
 }) {
   const { updateDoc, pruneEmpty } = React.useContext(DocumentEditorContext)
   const [inputValue, setInputValue] = React.useState(value)
   return (
-    <Attribute {...props}>
+    <Attribute disabled={disabled} {...props}>
       <div className="max-w-md flex">
         <div className="w-full">
           <Autocomplete

--- a/app/lib/app/SecvisogramPage/View/WizardTab/editors/GenericEditor/Attributes/IdAttribute.js
+++ b/app/lib/app/SecvisogramPage/View/WizardTab/editors/GenericEditor/Attributes/IdAttribute.js
@@ -36,9 +36,15 @@ function useMatch(term, entries) {
  *  value: unknown
  *  onCollectIds?(): Promise<void | {id: string, name: string}[]>
  *  property: import('../../../shared/types').Property
+ *  disabled: boolean
  * }} props
  */
-export default function IdAttribute({ placeholder, onCollectIds, ...props }) {
+export default function IdAttribute({
+  placeholder,
+  onCollectIds,
+  disabled,
+  ...props
+}) {
   const { updateDoc, pruneEmpty } = React.useContext(DocumentEditorContext)
 
   const [value, setValue] = React.useState(/** @type string */ (props.value))
@@ -72,7 +78,7 @@ export default function IdAttribute({ placeholder, onCollectIds, ...props }) {
   }, [props.value])
 
   return (
-    <Attribute {...props}>
+    <Attribute disabled={disabled} {...props}>
       <div className="max-w-md flex">
         <div className="w-full">
           <Combobox
@@ -92,6 +98,7 @@ export default function IdAttribute({ placeholder, onCollectIds, ...props }) {
               required={true}
               onChange={handleChange}
               onFocus={handleFocus}
+              disabled={disabled}
             />
             {results && (
               <ComboboxPopover className="shadow-popup">

--- a/app/lib/app/SecvisogramPage/View/WizardTab/editors/GenericEditor/Attributes/TextAreaAttribute.js
+++ b/app/lib/app/SecvisogramPage/View/WizardTab/editors/GenericEditor/Attributes/TextAreaAttribute.js
@@ -14,6 +14,7 @@ import DocumentEditorContext from '../../../../shared/DocumentEditorContext.js'
  *  instancePath: string[]
  *  value: unknown
  *  property: import('../../../shared/types').Property
+ *  disabled: boolean
  * }} props
  */
 export default function TextAreaAttribute({
@@ -23,11 +24,12 @@ export default function TextAreaAttribute({
   required = false,
   readOnly = false,
   value,
+  disabled,
   ...props
 }) {
   const { updateDoc, pruneEmpty } = React.useContext(DocumentEditorContext)
   return (
-    <Attribute {...props}>
+    <Attribute disabled={disabled} {...props}>
       <div className="max-w-md flex items-center justify-center">
         <div className="w-full">
           <textarea
@@ -44,6 +46,7 @@ export default function TextAreaAttribute({
                 pruneEmpty()
               }
             }}
+            disabled={disabled}
           />
         </div>
       </div>

--- a/app/lib/app/SecvisogramPage/View/WizardTab/editors/GenericEditor/Attributes/TextAttribute.js
+++ b/app/lib/app/SecvisogramPage/View/WizardTab/editors/GenericEditor/Attributes/TextAttribute.js
@@ -14,6 +14,7 @@ import DocumentEditorContext from '../../../../shared/DocumentEditorContext.js'
  *  instancePath: string[]
  *  value: unknown
  *  property: import('../../../shared/types').Property
+ *  disabled: boolean
  * }} props
  */
 export default function TextAttribute({
@@ -24,11 +25,12 @@ export default function TextAttribute({
   required = false,
   readOnly = false,
   value,
+  disabled,
   ...props
 }) {
   const { updateDoc, pruneEmpty } = React.useContext(DocumentEditorContext)
   return (
-    <Attribute {...props}>
+    <Attribute disabled={disabled} {...props}>
       <div className="max-w-md flex items-baseline justify-center">
         <div className="w-full">
           <input
@@ -46,6 +48,7 @@ export default function TextAttribute({
                 pruneEmpty()
               }
             }}
+            disabled={disabled}
           />
         </div>
       </div>

--- a/app/lib/app/SecvisogramPage/View/WizardTab/editors/GenericEditor/Attributes/shared/Attribute.js
+++ b/app/lib/app/SecvisogramPage/View/WizardTab/editors/GenericEditor/Attributes/shared/Attribute.js
@@ -17,6 +17,7 @@ import RelevanceLevelContext from '../../../../shared/context/RelevanceLevelCont
  *  instancePath: string[]
  *  children?: React.ReactNode | ((params: {}) => React.ReactNode)
  *  property: import('../../../../shared/types').Property
+ *  disabled: boolean
  * }} props
  * @template V
  */
@@ -26,6 +27,7 @@ export default function Attribute({
   instancePath,
   children,
   property,
+  disabled,
 }) {
   const { errors, doc } = React.useContext(DocumentEditorContext)
   const { selectedRelevanceLevel, relevanceLevels } = React.useContext(
@@ -62,7 +64,7 @@ export default function Attribute({
 
   return showAttribute ? (
     <section
-      className="mb-2"
+      className={'mb-2' + (disabled ? ' opacity-50' : '')}
       data-testid={`attribute-${instancePath.join('-')}`}
     >
       <div

--- a/app/lib/app/SecvisogramPage/View/WizardTab/schema.js
+++ b/app/lib/app/SecvisogramPage/View/WizardTab/schema.js
@@ -7803,7 +7803,7 @@ export default /** @type {const} */ ({
                                         'docs/user/vulnerabilities/vulnerability/scores/score/cvss_v2-usage.en.md',
                                     },
                                     relevanceLevels: {
-                                      csafInformationalAdvisory: 'excluded',
+                                      csaf_informational_advisory: 'excluded',
                                     },
                                     i18n: {
                                       title: 'CvssV2VersionTitle',
@@ -7830,7 +7830,7 @@ export default /** @type {const} */ ({
                                         'docs/user/vulnerabilities/vulnerability/scores/score/cvss_v2-usage.en.md',
                                     },
                                     relevanceLevels: {
-                                      csafInformationalAdvisory: 'excluded',
+                                      csaf_informational_advisory: 'excluded',
                                     },
                                     i18n: {
                                       title: 'CvssV2VectorStringTitle',
@@ -7860,12 +7860,12 @@ export default /** @type {const} */ ({
                                         'docs/user/vulnerabilities/vulnerability/scores/score/cvss_v2-usage.en.md',
                                     },
                                     relevanceLevels: {
-                                      csafBase: 'best_practice',
-                                      csafSecurityIncidentResponse:
+                                      csaf_base: 'best_practice',
+                                      csaf_security_incident_response:
                                         'best_practice',
-                                      csafInformationalAdvisory: 'excluded',
-                                      csafSecurityAdvisory: 'best_practice',
-                                      csafVex: 'best_practice',
+                                      csaf_informational_advisory: 'excluded',
+                                      csaf_security_advisory: 'best_practice',
+                                      csaf_vex: 'best_practice',
                                     },
                                     i18n: {
                                       title: 'CvssV2AccessVectorTitle',
@@ -7898,12 +7898,12 @@ export default /** @type {const} */ ({
                                         'docs/user/vulnerabilities/vulnerability/scores/score/cvss_v2-usage.en.md',
                                     },
                                     relevanceLevels: {
-                                      csafBase: 'best_practice',
-                                      csafSecurityIncidentResponse:
+                                      csaf_base: 'best_practice',
+                                      csaf_security_incident_response:
                                         'best_practice',
-                                      csafInformationalAdvisory: 'excluded',
-                                      csafSecurityAdvisory: 'best_practice',
-                                      csafVex: 'best_practice',
+                                      csaf_informational_advisory: 'excluded',
+                                      csaf_security_advisory: 'best_practice',
+                                      csaf_vex: 'best_practice',
                                     },
                                     i18n: {
                                       title: 'CvssV2AccessComplexityTitle',
@@ -7932,12 +7932,12 @@ export default /** @type {const} */ ({
                                         'docs/user/vulnerabilities/vulnerability/scores/score/cvss_v2-usage.en.md',
                                     },
                                     relevanceLevels: {
-                                      csafBase: 'best_practice',
-                                      csafSecurityIncidentResponse:
+                                      csaf_base: 'best_practice',
+                                      csaf_security_incident_response:
                                         'best_practice',
-                                      csafInformationalAdvisory: 'excluded',
-                                      csafSecurityAdvisory: 'best_practice',
-                                      csafVex: 'best_practice',
+                                      csaf_informational_advisory: 'excluded',
+                                      csaf_security_advisory: 'best_practice',
+                                      csaf_vex: 'best_practice',
                                     },
                                     i18n: {
                                       title: 'CvssV2AuthenticationTitle',
@@ -7966,12 +7966,12 @@ export default /** @type {const} */ ({
                                         'docs/user/vulnerabilities/vulnerability/scores/score/cvss_v2-usage.en.md',
                                     },
                                     relevanceLevels: {
-                                      csafBase: 'best_practice',
-                                      csafSecurityIncidentResponse:
+                                      csaf_base: 'best_practice',
+                                      csaf_security_incident_response:
                                         'best_practice',
-                                      csafInformationalAdvisory: 'excluded',
-                                      csafSecurityAdvisory: 'best_practice',
-                                      csafVex: 'best_practice',
+                                      csaf_informational_advisory: 'excluded',
+                                      csaf_security_advisory: 'best_practice',
+                                      csaf_vex: 'best_practice',
                                     },
                                     i18n: {
                                       title: 'CvssV2ConfidentialityImpactTitle',
@@ -8000,12 +8000,12 @@ export default /** @type {const} */ ({
                                         'docs/user/vulnerabilities/vulnerability/scores/score/cvss_v2-usage.en.md',
                                     },
                                     relevanceLevels: {
-                                      csafBase: 'best_practice',
-                                      csafSecurityIncidentResponse:
+                                      csaf_base: 'best_practice',
+                                      csaf_security_incident_response:
                                         'best_practice',
-                                      csafInformationalAdvisory: 'excluded',
-                                      csafSecurityAdvisory: 'best_practice',
-                                      csafVex: 'best_practice',
+                                      csaf_informational_advisory: 'excluded',
+                                      csaf_security_advisory: 'best_practice',
+                                      csaf_vex: 'best_practice',
                                     },
                                     i18n: {
                                       title: 'CvssV2IntegrityImpactTitle',
@@ -8034,12 +8034,12 @@ export default /** @type {const} */ ({
                                         'docs/user/vulnerabilities/vulnerability/scores/score/cvss_v2-usage.en.md',
                                     },
                                     relevanceLevels: {
-                                      csafBase: 'best_practice',
-                                      csafSecurityIncidentResponse:
+                                      csaf_base: 'best_practice',
+                                      csaf_security_incident_response:
                                         'best_practice',
-                                      csafInformationalAdvisory: 'excluded',
-                                      csafSecurityAdvisory: 'best_practice',
-                                      csafVex: 'best_practice',
+                                      csaf_informational_advisory: 'excluded',
+                                      csaf_security_advisory: 'best_practice',
+                                      csaf_vex: 'best_practice',
                                     },
                                     i18n: {
                                       title: 'CvssV2AvailabilityImpactTitle',
@@ -8067,7 +8067,7 @@ export default /** @type {const} */ ({
                                         'docs/user/vulnerabilities/vulnerability/scores/score/cvss_v2-usage.en.md',
                                     },
                                     relevanceLevels: {
-                                      csafInformationalAdvisory: 'excluded',
+                                      csaf_informational_advisory: 'excluded',
                                     },
                                     i18n: {
                                       title: 'CvssV2BaseScoreTitle',
@@ -8094,12 +8094,12 @@ export default /** @type {const} */ ({
                                         'docs/user/vulnerabilities/vulnerability/scores/score/cvss_v2-usage.en.md',
                                     },
                                     relevanceLevels: {
-                                      csafBase: 'nice_to_know',
-                                      csafSecurityIncidentResponse:
+                                      csaf_base: 'nice_to_know',
+                                      csaf_security_incident_response:
                                         'nice_to_know',
-                                      csafInformationalAdvisory: 'excluded',
-                                      csafSecurityAdvisory: 'nice_to_know',
-                                      csafVex: 'nice_to_know',
+                                      csaf_informational_advisory: 'excluded',
+                                      csaf_security_advisory: 'nice_to_know',
+                                      csaf_vex: 'nice_to_know',
                                     },
                                     i18n: {
                                       title: 'CvssV2ExploitabilityTitle',
@@ -8134,12 +8134,12 @@ export default /** @type {const} */ ({
                                         'docs/user/vulnerabilities/vulnerability/scores/score/cvss_v2-usage.en.md',
                                     },
                                     relevanceLevels: {
-                                      csafBase: 'want_to_have',
-                                      csafSecurityIncidentResponse:
+                                      csaf_base: 'want_to_have',
+                                      csaf_security_incident_response:
                                         'want_to_have',
-                                      csafInformationalAdvisory: 'excluded',
-                                      csafSecurityAdvisory: 'want_to_have',
-                                      csafVex: 'want_to_have',
+                                      csaf_informational_advisory: 'excluded',
+                                      csaf_security_advisory: 'want_to_have',
+                                      csaf_vex: 'want_to_have',
                                     },
                                     i18n: {
                                       title: 'CvssV2RemediationLevelTitle',
@@ -8174,12 +8174,12 @@ export default /** @type {const} */ ({
                                         'docs/user/vulnerabilities/vulnerability/scores/score/cvss_v2-usage.en.md',
                                     },
                                     relevanceLevels: {
-                                      csafBase: 'want_to_have',
-                                      csafSecurityIncidentResponse:
+                                      csaf_base: 'want_to_have',
+                                      csaf_security_incident_response:
                                         'want_to_have',
-                                      csafInformationalAdvisory: 'excluded',
-                                      csafSecurityAdvisory: 'want_to_have',
-                                      csafVex: 'want_to_have',
+                                      csaf_informational_advisory: 'excluded',
+                                      csaf_security_advisory: 'want_to_have',
+                                      csaf_vex: 'want_to_have',
                                     },
                                     i18n: {
                                       title: 'CvssV2ReportConfidenceTitle',
@@ -8212,12 +8212,12 @@ export default /** @type {const} */ ({
                                         'docs/user/vulnerabilities/vulnerability/scores/score/cvss_v2-usage.en.md',
                                     },
                                     relevanceLevels: {
-                                      csafBase: 'want_to_have',
-                                      csafSecurityIncidentResponse:
+                                      csaf_base: 'want_to_have',
+                                      csaf_security_incident_response:
                                         'want_to_have',
-                                      csafInformationalAdvisory: 'excluded',
-                                      csafSecurityAdvisory: 'want_to_have',
-                                      csafVex: 'want_to_have',
+                                      csaf_informational_advisory: 'excluded',
+                                      csaf_security_advisory: 'want_to_have',
+                                      csaf_vex: 'want_to_have',
                                     },
                                     i18n: {
                                       title: 'CvssV2TemporalScoreTitle',
@@ -8245,11 +8245,12 @@ export default /** @type {const} */ ({
                                         'docs/user/vulnerabilities/vulnerability/scores/score/cvss_v2-usage.en.md',
                                     },
                                     relevanceLevels: {
-                                      csafBase: 'optional',
-                                      csafSecurityIncidentResponse: 'optional',
-                                      csafInformationalAdvisory: 'excluded',
-                                      csafSecurityAdvisory: 'optional',
-                                      csafVex: 'optional',
+                                      csaf_base: 'optional',
+                                      csaf_security_incident_response:
+                                        'optional',
+                                      csaf_informational_advisory: 'excluded',
+                                      csaf_security_advisory: 'optional',
+                                      csaf_vex: 'optional',
                                     },
                                     i18n: {
                                       title:
@@ -8286,11 +8287,12 @@ export default /** @type {const} */ ({
                                         'docs/user/vulnerabilities/vulnerability/scores/score/cvss_v2-usage.en.md',
                                     },
                                     relevanceLevels: {
-                                      csafBase: 'optional',
-                                      csafSecurityIncidentResponse: 'optional',
-                                      csafInformationalAdvisory: 'excluded',
-                                      csafSecurityAdvisory: 'optional',
-                                      csafVex: 'optional',
+                                      csaf_base: 'optional',
+                                      csaf_security_incident_response:
+                                        'optional',
+                                      csaf_informational_advisory: 'excluded',
+                                      csaf_security_advisory: 'optional',
+                                      csaf_vex: 'optional',
                                     },
                                     i18n: {
                                       title: 'CvssV2TargetDistributionTitle',
@@ -8325,11 +8327,12 @@ export default /** @type {const} */ ({
                                         'docs/user/vulnerabilities/vulnerability/scores/score/cvss_v2-usage.en.md',
                                     },
                                     relevanceLevels: {
-                                      csafBase: 'optional',
-                                      csafSecurityIncidentResponse: 'optional',
-                                      csafInformationalAdvisory: 'excluded',
-                                      csafSecurityAdvisory: 'optional',
-                                      csafVex: 'optional',
+                                      csaf_base: 'optional',
+                                      csaf_security_incident_response:
+                                        'optional',
+                                      csaf_informational_advisory: 'excluded',
+                                      csaf_security_advisory: 'optional',
+                                      csaf_vex: 'optional',
                                     },
                                     i18n: {
                                       title:
@@ -8364,11 +8367,12 @@ export default /** @type {const} */ ({
                                         'docs/user/vulnerabilities/vulnerability/scores/score/cvss_v2-usage.en.md',
                                     },
                                     relevanceLevels: {
-                                      csafBase: 'optional',
-                                      csafSecurityIncidentResponse: 'optional',
-                                      csafInformationalAdvisory: 'excluded',
-                                      csafSecurityAdvisory: 'optional',
-                                      csafVex: 'optional',
+                                      csaf_base: 'optional',
+                                      csaf_security_incident_response:
+                                        'optional',
+                                      csaf_informational_advisory: 'excluded',
+                                      csaf_security_advisory: 'optional',
+                                      csaf_vex: 'optional',
                                     },
                                     i18n: {
                                       title: 'CvssV2IntegrityRequirementTitle',
@@ -8402,11 +8406,12 @@ export default /** @type {const} */ ({
                                         'docs/user/vulnerabilities/vulnerability/scores/score/cvss_v2-usage.en.md',
                                     },
                                     relevanceLevels: {
-                                      csafBase: 'optional',
-                                      csafSecurityIncidentResponse: 'optional',
-                                      csafInformationalAdvisory: 'excluded',
-                                      csafSecurityAdvisory: 'optional',
-                                      csafVex: 'optional',
+                                      csaf_base: 'optional',
+                                      csaf_security_incident_response:
+                                        'optional',
+                                      csaf_informational_advisory: 'excluded',
+                                      csaf_security_advisory: 'optional',
+                                      csaf_vex: 'optional',
                                     },
                                     i18n: {
                                       title:
@@ -8440,11 +8445,12 @@ export default /** @type {const} */ ({
                                         'docs/user/vulnerabilities/vulnerability/scores/score/cvss_v2-usage.en.md',
                                     },
                                     relevanceLevels: {
-                                      csafBase: 'optional',
-                                      csafSecurityIncidentResponse: 'optional',
-                                      csafInformationalAdvisory: 'excluded',
-                                      csafSecurityAdvisory: 'optional',
-                                      csafVex: 'optional',
+                                      csaf_base: 'optional',
+                                      csaf_security_incident_response:
+                                        'optional',
+                                      csaf_informational_advisory: 'excluded',
+                                      csaf_security_advisory: 'optional',
+                                      csaf_vex: 'optional',
                                     },
                                     i18n: {
                                       title: 'CvssV2EnvironmentalScoreTitle',

--- a/app/lib/app/SecvisogramPage/View/WizardTab/schema.js
+++ b/app/lib/app/SecvisogramPage/View/WizardTab/schema.js
@@ -1701,7 +1701,6 @@ export default /** @type {const} */ ({
                               description:
                                 'Specifies a version string to denote clearly the evolution of the content of the document. Format must be either integer or semantic versioning.',
                               metaData: {
-                                uiType: 'STRING_MULTI_LINE',
                                 userDocumentation: {
                                   specification:
                                     'docs/user/document/tracking/revision_history/revision/number-spec.en.md',

--- a/app/lib/app/SecvisogramPage/View/WizardTab/shared/types.ts
+++ b/app/lib/app/SecvisogramPage/View/WizardTab/shared/types.ts
@@ -50,6 +50,10 @@ type MetaData = Readonly<{
     description: string
   }
   options?: ReadonlyArray<string>
+  disable?: {
+    ifStandaloneMode: boolean
+    ifServerMode: boolean
+  }
 }>
 
 type RelevanceLevel =

--- a/app/scripts/importUiMetaData/metaData.js
+++ b/app/scripts/importUiMetaData/metaData.js
@@ -950,7 +950,6 @@ export default {
       csaf_vex: 'mandatory',
     },
     i18n: { title: 'VersionTitle', description: 'VersionDescription' },
-    uiType: 'STRING_MULTI_LINE',
     disable: {
       ifStandaloneMode: false,
       ifServerMode: true,


### PR DESCRIPTION
Disables field based on mode (standalone/server) and metadata

comes with some additional fixes:
* correct input type for `document.tracking.revision_history.number` (should not be a multiline text)
* more accessible clearing of non-mandatory fields in cvss v3