### PR TITLE
Fix/error prefix matching

### DIFF
--- a/app/cypress/e2e/SecvisogramPage/WizardTab.cy.js
+++ b/app/cypress/e2e/SecvisogramPage/WizardTab.cy.js
@@ -115,4 +115,31 @@ describe('SecvisogramPage / WizardTab', function () {
     cy.get(`[data-testid="layer-button-nice_to_know"]`).click()
     cy.get(`[data-testid="attribute-document-lang"]`).should('exist')
   })
+
+  it('shows errors in sidebar according to selected path', function () {
+    cy.intercept(
+      '/.well-known/appspecific/de.bsi.secvisogram.json',
+      getLoginEnabledConfig()
+    ).as('wellKnownAppConfig')
+
+    cy.visit('?tab=WIZZARD')
+    cy.wait('@wellKnownAppConfig')
+
+    cy.get(`[data-testid="document-publisher-infoButton"]`).click()
+
+    // there should be 3 error cards under /document/publisher for a default minimal document
+    cy.get(`[data-testid="error-cards"] div`).should('have.length', 3)
+
+    cy.get(`[data-testid="menu_entry-/document/publisher"]`).click()
+    cy.get(`[data-testid="document-publisher-name-infoButton"]`).click()
+
+    // there should be one error card for /document/publisher/name and none for the sibling namespace
+    cy.get(`[data-testid="error-cards"] div`).should('have.length', 1)
+    cy.get(`[data-testid="error_card-/document/publisher/name-0"]`).should(
+      'exist'
+    )
+    cy.get(`[data-testid="error_card-/document/publisher/namespace-1"]`).should(
+      'not.exist'
+    )
+  })
 })

--- a/app/lib/app/SecvisogramPage/View/SideBar/ErrorPanel.js
+++ b/app/lib/app/SecvisogramPage/View/SideBar/ErrorPanel.js
@@ -22,7 +22,7 @@ export default function ErrorPanel({ selectedPath }) {
       <div className="w-full px-4 pt-2">
         {selectedPath.length ? 'Context specific Errors:' : 'All errors:'}
       </div>
-      <div className="p-3">
+      <div className="p-3" data-testid="error-cards">
         {errorsUnderPath.map((err, i) => {
           const color =
             err.type === 'error'
@@ -36,6 +36,7 @@ export default function ErrorPanel({ selectedPath }) {
             <div
               key={i}
               className={'p-2 m-1 rounded border hover:cursor-pointer ' + color}
+              data-testid={`error_card-${err.instancePath}-${i}`}
               onClick={() =>
                 setSelectedPath(err.instancePath.split('/').slice(1))
               }

--- a/app/lib/app/SecvisogramPage/View/SideBar/ErrorPanel.js
+++ b/app/lib/app/SecvisogramPage/View/SideBar/ErrorPanel.js
@@ -13,9 +13,14 @@ export default function ErrorPanel({ selectedPath }) {
   const { errors } = React.useContext(DocumentEditorContext)
   const { setSelectedPath } = React.useContext(SelectedPathContext)
 
-  const errorsUnderPath = errors.filter((error) =>
-    error.instancePath.startsWith('/' + selectedPath.join('/'))
-  )
+  const errorsUnderPath = errors.filter((error) => {
+    const selectedPathAsString = '/' + selectedPath.join('/')
+    return (
+      error.instancePath === selectedPathAsString ||
+      (error.instancePath.startsWith(selectedPathAsString) &&
+        error.instancePath.slice(selectedPathAsString.length).includes('/'))
+    )
+  })
 
   return (
     <>


### PR DESCRIPTION
 filter errors to be shown in sidebar

matching prefix only showed errors for field "...namespace" when field "...name" is selected
