### PR TITLE
fix(pruneEmpty.js): allow undefined input

### DIFF
--- a/app/lib/app/shared/pruneEmpty.js
+++ b/app/lib/app/shared/pruneEmpty.js
@@ -8,7 +8,8 @@ import { isEmpty } from 'lodash/fp.js'
  * @type {({}) => {}}
  */
 export default function pruneEmpty(obj) {
-  if (typeof obj === 'string' || typeof obj === 'number') return obj
+  if (typeof obj === 'string' || typeof obj === 'number' || obj === undefined)
+    return obj
   if (Array.isArray(obj)) return obj.map((item) => pruneEmpty(item))
   return {
     ...Object.fromEntries(


### PR DESCRIPTION
There was an error in `pruneEmpty` on undefined input. This occurred for example when trying to switch tabs from editor to another tab having an incomplete CVSS vector.