### PR TITLE
updated ajv-formats version

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -16,7 +16,7 @@
         "@reach/alert-dialog": "^0.18.0",
         "@reach/combobox": "^0.16.5",
         "ajv": "^8.10.0",
-        "ajv-formats": "^2.1.1",
+        "ajv-formats": "^3.0.0-rc.0",
         "bcp47": "^1.1.2",
         "cvss2js": "^1.1.0",
         "i18next": "^22.4.12",
@@ -3400,9 +3400,9 @@
       }
     },
     "node_modules/ajv-formats": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
-      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "version": "3.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.0-rc.0.tgz",
+      "integrity": "sha512-eyqaGv4OE7RMgW2GNujqwJZWFjOT4z0tQZTVnYiWtSDh9TFwD8CIsJ6ta065IblpZXcV3wFuy8y2gKFb1d0uPw==",
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -4712,6 +4712,23 @@
       },
       "peerDependencies": {
         "webpack": "^5.1.0"
+      }
+    },
+    "node_modules/copy-webpack-plugin/node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/copy-webpack-plugin/node_modules/array-union": {
@@ -9494,6 +9511,23 @@
         "webpack": "^5.0.0"
       }
     },
+    "node_modules/mini-css-extract-plugin/node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/mini-css-extract-plugin/node_modules/schema-utils": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.0.0.tgz",
@@ -13093,6 +13127,23 @@
         "webpack": "^4.0.0 || ^5.0.0"
       }
     },
+    "node_modules/webpack-dev-middleware/node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/webpack-dev-middleware/node_modules/schema-utils": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.0.0.tgz",
@@ -13163,6 +13214,23 @@
       },
       "peerDependenciesMeta": {
         "webpack-cli": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
           "optional": true
         }
       }
@@ -16066,9 +16134,9 @@
       }
     },
     "ajv-formats": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
-      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "version": "3.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.0-rc.0.tgz",
+      "integrity": "sha512-eyqaGv4OE7RMgW2GNujqwJZWFjOT4z0tQZTVnYiWtSDh9TFwD8CIsJ6ta065IblpZXcV3wFuy8y2gKFb1d0uPw==",
       "requires": {
         "ajv": "^8.0.0"
       }
@@ -17010,6 +17078,15 @@
         "serialize-javascript": "^6.0.0"
       },
       "dependencies": {
+        "ajv-formats": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+          "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+          "dev": true,
+          "requires": {
+            "ajv": "^8.0.0"
+          }
+        },
         "array-union": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/array-union/-/array-union-3.0.1.tgz",
@@ -20455,6 +20532,15 @@
         "schema-utils": "^4.0.0"
       },
       "dependencies": {
+        "ajv-formats": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+          "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+          "dev": true,
+          "requires": {
+            "ajv": "^8.0.0"
+          }
+        },
         "schema-utils": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.0.0.tgz",
@@ -23109,6 +23195,15 @@
         "schema-utils": "^4.0.0"
       },
       "dependencies": {
+        "ajv-formats": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+          "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+          "dev": true,
+          "requires": {
+            "ajv": "^8.0.0"
+          }
+        },
         "schema-utils": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.0.0.tgz",
@@ -23160,6 +23255,15 @@
         "ws": "^8.4.2"
       },
       "dependencies": {
+        "ajv-formats": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+          "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+          "dev": true,
+          "requires": {
+            "ajv": "^8.0.0"
+          }
+        },
         "schema-utils": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.0.0.tgz",

--- a/app/package.json
+++ b/app/package.json
@@ -26,7 +26,7 @@
     "@reach/alert-dialog": "^0.18.0",
     "@reach/combobox": "^0.16.5",
     "ajv": "^8.10.0",
-    "ajv-formats": "^2.1.1",
+    "ajv-formats": "^3.0.0-rc.0",
     "bcp47": "^1.1.2",
     "cvss2js": "^1.1.0",
     "i18next": "^22.4.12",


### PR DESCRIPTION
Regarding issue [#20](https://github.com/secvisogram/csaf-validator-lib/issues/20)

Updated ajv-formats version like in csaf-validator-lib repo. 
See [PR](https://github.com/secvisogram/csaf-validator-lib/pull/105)