### PR TITLE
fix: monaco-editor popup is now displayed above the header

### DIFF
--- a/app/lib/app/SecvisogramPage/View.js
+++ b/app/lib/app/SecvisogramPage/View.js
@@ -1073,7 +1073,7 @@ function View({
                   </div>
                 )}
                 <div
-                  className="row-span-2 relative overflow-auto h-full bg-white"
+                  className="row-span-2 relative h-full bg-white"
                   key={activeTab}
                 >
                   {activeTab === 'EDITOR' ? (


### PR DESCRIPTION
Fix for Issue https://github.com/secvisogram/secvisogram/issues/325

Remove overflow-auto class from content container below the navigation.
This implicitly sets the overflow css attribute to `visible`, which makes it possible for absolute containers like the monaco-editor popup to be displayed on top of the navigation.
Testing showed none of the pages caused the affected container to trigger scrollbars so this shouldn't cause any issues.