### PR TITLE
feat: add fill functions for revision history

### DIFF
--- a/app/cypress/e2e/SecvisogramPage/FormEditorTab.cy.js
+++ b/app/cypress/e2e/SecvisogramPage/FormEditorTab.cy.js
@@ -687,13 +687,11 @@ describe('SecvisogramPage / FormEditor Tab', function () {
       cy.get(
         '[data-testid="attribute-document-tracking-revision_history-0-date"] input[type="date"]'
       )
-        .invoke('attr', 'value', '2020-01-01')
-        .trigger('change')
+        .type('2020-01-01')
       cy.get(
         '[data-testid="attribute-document-tracking-revision_history-0-date"] input[type="time"]'
       )
-        .invoke('attr', 'value', '12:00')
-        .trigger('change')
+        .type('13:41')
 
       // current release should still be empty
       cy.get('[data-testid="document/tracking-fieldButton"]').click()
@@ -713,7 +711,7 @@ describe('SecvisogramPage / FormEditor Tab', function () {
       ).should('have.value', '2020-01-01')
       cy.get(
         '[data-testid="attribute-document-tracking-current_release_date"] input[type="time"]'
-      ).should('have.value', '12:00')
+      ).should('have.value', '13:41')
 
       // just regenerating should be still the same
       cy.get(
@@ -724,7 +722,7 @@ describe('SecvisogramPage / FormEditor Tab', function () {
       ).should('have.value', '2020-01-01')
       cy.get(
         '[data-testid="attribute-document-tracking-current_release_date"] input[type="time"]'
-      ).should('have.value', '12:00')
+      ).should('have.value', '13:41')
     })
 
     it('fill initial release date', function () {
@@ -760,13 +758,11 @@ describe('SecvisogramPage / FormEditor Tab', function () {
       cy.get(
         '[data-testid="attribute-document-tracking-revision_history-0-date"] input[type="date"]'
       )
-        .invoke('attr', 'value', '2020-01-01')
-        .trigger('change')
+        .type('2020-01-01')
       cy.get(
         '[data-testid="attribute-document-tracking-revision_history-0-date"] input[type="time"]'
       )
-        .invoke('attr', 'value', '12:00')
-        .trigger('change')
+        .type('13:41')
       cy.get(
         '[data-testid="attribute-document-tracking-revision_history-0-number"] input'
       )
@@ -791,7 +787,7 @@ describe('SecvisogramPage / FormEditor Tab', function () {
       ).should('have.value', '2020-01-01')
       cy.get(
         '[data-testid="attribute-document-tracking-initial_release_date"] input[type="time"]'
-      ).should('have.value', '12:00')
+      ).should('have.value', '13:41')
 
       // just regenerating should be still the same
       cy.get(
@@ -802,7 +798,77 @@ describe('SecvisogramPage / FormEditor Tab', function () {
       ).should('have.value', '2020-01-01')
       cy.get(
         '[data-testid="attribute-document-tracking-initial_release_date"] input[type="time"]'
-      ).should('have.value', '12:00')
+      ).should('have.value', '13:41')
+    })
+
+    it('fill release dates with more than one revision history entry', function () {
+      cy.visit('?tab=EDITOR')
+
+      // create first revision history item
+      cy.get('[data-testid="menu_entry-/document/tracking"]').click()
+      cy.get(
+        '[data-testid="menu_entry-/document/tracking/revision_history-add_item_button"]'
+      ).click({ force: true })
+      cy.get(
+        '[data-testid="menu_entry-/document/tracking/revision_history/0"]'
+      ).click()
+      cy.get(
+        '[data-testid="attribute-document-tracking-revision_history-0-date"] input[type="date"]'
+      )
+        .type('2020-01-01')
+      cy.get(
+        '[data-testid="attribute-document-tracking-revision_history-0-date"] input[type="time"]'
+      )
+        .type('13:41')
+      cy.get(
+        '[data-testid="attribute-document-tracking-revision_history-0-number"] input'
+      )
+        .clear()
+        .type('1.0.0')
+
+      // create second revision history item
+      cy.get(
+        '[data-testid="menu_entry-/document/tracking/revision_history-add_item_button"]'
+      ).click({ force: true })
+      cy.get(
+        '[data-testid="menu_entry-/document/tracking/revision_history/1"]'
+      ).click()
+      cy.get(
+        '[data-testid="attribute-document-tracking-revision_history-1-date"] input[type="date"]'
+      )
+        .type('2021-01-01')
+      cy.get(
+        '[data-testid="attribute-document-tracking-revision_history-1-date"] input[type="time"]'
+      )
+        .type('13:15')
+      cy.get(
+        '[data-testid="attribute-document-tracking-revision_history-1-number"] input'
+      )
+        .clear()
+        .type('1.5.0')
+
+      // initial release generate button should enter date and time of version 1.0.0
+      cy.get('[data-testid="document/tracking-fieldButton"]').click()
+      cy.get(
+        '[data-testid="document-tracking-initial_release_date-generateButton"]'
+      ).click()
+      cy.get(
+        '[data-testid="attribute-document-tracking-initial_release_date"] input[type="date"]'
+      ).should('have.value', '2020-01-01')
+      cy.get(
+        '[data-testid="attribute-document-tracking-initial_release_date"] input[type="time"]'
+      ).should('have.value', '13:41')
+
+      // current release generate button should enter date and time of version 1.5.0
+      cy.get(
+        '[data-testid="document-tracking-current_release_date-generateButton"]'
+      ).click()
+      cy.get(
+        '[data-testid="attribute-document-tracking-current_release_date"] input[type="date"]'
+      ).should('have.value', '2021-01-01')
+      cy.get(
+        '[data-testid="attribute-document-tracking-current_release_date"] input[type="time"]'
+      ).should('have.value', '13:15')
     })
   })
 })

--- a/app/cypress/e2e/SecvisogramPage/FormEditorTab.cy.js
+++ b/app/cypress/e2e/SecvisogramPage/FormEditorTab.cy.js
@@ -607,4 +607,202 @@ describe('SecvisogramPage / FormEditor Tab', function () {
       '[data-testid="attribute-product_tree-branches-0-branches-0-product-name"] input'
     ).should('have.value', 'Vendor A Product DEF')
   })
+
+  describe('fill functions for revision history', function () {
+    it('fill date of revision', function () {
+      cy.visit('?tab=EDITOR')
+      const now = new Date(2020, 0, 1, 10, 30)
+      cy.clock(now)
+
+      // create new revision history item
+      cy.get('[data-testid="menu_entry-/document/tracking"]').click()
+      cy.get(
+        '[data-testid="menu_entry-/document/tracking/revision_history-add_item_button"]'
+      ).click({ force: true })
+      cy.get(
+        '[data-testid="menu_entry-/document/tracking/revision_history/0"]'
+      ).click()
+
+      // values should be empty first
+      cy.get(
+        '[data-testid="attribute-document-tracking-revision_history-0-date"] input[type="date"]'
+      ).should('be.empty')
+      cy.get(
+        '[data-testid="attribute-document-tracking-revision_history-0-date"] input[type="time"]'
+      ).should('be.empty')
+
+      // and filled with a value after clicking the generate button
+      cy.get(
+        '[data-testid="document-tracking-revision_history-0-date-generateButton"]'
+      ).click()
+      cy.get(
+        '[data-testid="attribute-document-tracking-revision_history-0-date"] input[type="date"]'
+      ).should('have.value', '2020-01-01')
+      cy.get(
+        '[data-testid="attribute-document-tracking-revision_history-0-date"] input[type="time"]'
+      ).should('have.value', '11:00')
+
+      // just regenerating should be still the same
+      cy.get(
+        '[data-testid="document-tracking-revision_history-0-date-generateButton"]'
+      ).click()
+      cy.get(
+        '[data-testid="attribute-document-tracking-revision_history-0-date"] input[type="date"]'
+      ).should('have.value', '2020-01-01')
+      cy.get(
+        '[data-testid="attribute-document-tracking-revision_history-0-date"] input[type="time"]'
+      ).should('have.value', '11:00')
+    })
+
+    it('fill current release date', function () {
+      cy.visit('?tab=EDITOR')
+
+      // input should be empty first
+      cy.get('[data-testid="menu_entry-/document/tracking"]').click()
+      cy.get(
+        '[data-testid="attribute-document-tracking-current_release_date"] input[type="date"]'
+      ).should('be.empty')
+      cy.get(
+        '[data-testid="attribute-document-tracking-current_release_date"] input[type="time"]'
+      ).should('be.empty')
+
+      // generate button should do nothing without revision history entries
+      cy.get(
+        '[data-testid="document-tracking-current_release_date-generateButton"]'
+      )
+      cy.get(
+        '[data-testid="attribute-document-tracking-current_release_date"] input[type="date"]'
+      ).should('be.empty')
+      cy.get(
+        '[data-testid="attribute-document-tracking-current_release_date"] input[type="time"]'
+      ).should('be.empty')
+
+      // create new revision history item
+      cy.get(
+        '[data-testid="menu_entry-/document/tracking/revision_history-add_item_button"]'
+      ).click({ force: true })
+      cy.get(
+        '[data-testid="menu_entry-/document/tracking/revision_history/0"]'
+      ).click()
+      cy.get(
+        '[data-testid="attribute-document-tracking-revision_history-0-date"] input[type="date"]'
+      )
+        .invoke('attr', 'value', '2020-01-01')
+        .trigger('change')
+      cy.get(
+        '[data-testid="attribute-document-tracking-revision_history-0-date"] input[type="time"]'
+      )
+        .invoke('attr', 'value', '12:00')
+        .trigger('change')
+
+      // current release should still be empty
+      cy.get('[data-testid="document/tracking-fieldButton"]').click()
+      cy.get(
+        '[data-testid="attribute-document-tracking-current_release_date"] input[type="date"]'
+      ).should('be.empty')
+      cy.get(
+        '[data-testid="attribute-document-tracking-current_release_date"] input[type="time"]'
+      ).should('be.empty')
+
+      // generate button should enter correct date and time
+      cy.get(
+        '[data-testid="document-tracking-current_release_date-generateButton"]'
+      ).click()
+      cy.get(
+        '[data-testid="attribute-document-tracking-current_release_date"] input[type="date"]'
+      ).should('have.value', '2020-01-01')
+      cy.get(
+        '[data-testid="attribute-document-tracking-current_release_date"] input[type="time"]'
+      ).should('have.value', '12:00')
+
+      // just regenerating should be still the same
+      cy.get(
+        '[data-testid="document-tracking-current_release_date-generateButton"]'
+      ).click()
+      cy.get(
+        '[data-testid="attribute-document-tracking-current_release_date"] input[type="date"]'
+      ).should('have.value', '2020-01-01')
+      cy.get(
+        '[data-testid="attribute-document-tracking-current_release_date"] input[type="time"]'
+      ).should('have.value', '12:00')
+    })
+
+    it('fill initial release date', function () {
+      cy.visit('?tab=EDITOR')
+
+      // input should be empty first
+      cy.get('[data-testid="menu_entry-/document/tracking"]').click()
+      cy.get(
+        '[data-testid="attribute-document-tracking-initial_release_date"] input[type="date"]'
+      ).should('be.empty')
+      cy.get(
+        '[data-testid="attribute-document-tracking-initial_release_date"] input[type="time"]'
+      ).should('be.empty')
+
+      // generate button should do nothing without revision history entries
+      cy.get(
+        '[data-testid="document-tracking-initial_release_date-generateButton"]'
+      )
+      cy.get(
+        '[data-testid="attribute-document-tracking-initial_release_date"] input[type="date"]'
+      ).should('be.empty')
+      cy.get(
+        '[data-testid="attribute-document-tracking-initial_release_date"] input[type="time"]'
+      ).should('be.empty')
+
+      // create new revision history item
+      cy.get(
+        '[data-testid="menu_entry-/document/tracking/revision_history-add_item_button"]'
+      ).click({ force: true })
+      cy.get(
+        '[data-testid="menu_entry-/document/tracking/revision_history/0"]'
+      ).click()
+      cy.get(
+        '[data-testid="attribute-document-tracking-revision_history-0-date"] input[type="date"]'
+      )
+        .invoke('attr', 'value', '2020-01-01')
+        .trigger('change')
+      cy.get(
+        '[data-testid="attribute-document-tracking-revision_history-0-date"] input[type="time"]'
+      )
+        .invoke('attr', 'value', '12:00')
+        .trigger('change')
+      cy.get(
+        '[data-testid="attribute-document-tracking-revision_history-0-number"] input'
+      )
+        .clear()
+        .type('1.0.0')
+
+      // current release should still be empty
+      cy.get('[data-testid="document/tracking-fieldButton"]').click()
+      cy.get(
+        '[data-testid="attribute-document-tracking-initial_release_date"] input[type="date"]'
+      ).should('be.empty')
+      cy.get(
+        '[data-testid="attribute-document-tracking-initial_release_date"] input[type="time"]'
+      ).should('be.empty')
+
+      // generate button should enter correct date and time
+      cy.get(
+        '[data-testid="document-tracking-initial_release_date-generateButton"]'
+      ).click()
+      cy.get(
+        '[data-testid="attribute-document-tracking-initial_release_date"] input[type="date"]'
+      ).should('have.value', '2020-01-01')
+      cy.get(
+        '[data-testid="attribute-document-tracking-initial_release_date"] input[type="time"]'
+      ).should('have.value', '12:00')
+
+      // just regenerating should be still the same
+      cy.get(
+        '[data-testid="document-tracking-initial_release_date-generateButton"]'
+      ).click()
+      cy.get(
+        '[data-testid="attribute-document-tracking-initial_release_date"] input[type="date"]'
+      ).should('have.value', '2020-01-01')
+      cy.get(
+        '[data-testid="attribute-document-tracking-initial_release_date"] input[type="time"]'
+      ).should('have.value', '12:00')
+    })
+  })
 })

--- a/app/cypress/e2e/SecvisogramPage/FormEditorTab.cy.js
+++ b/app/cypress/e2e/SecvisogramPage/FormEditorTab.cy.js
@@ -815,16 +815,16 @@ describe('SecvisogramPage / FormEditor Tab', function () {
       cy.get(
         '[data-testid="attribute-document-tracking-revision_history-0-date"] input[type="date"]'
       )
-        .type('2020-02-01')
+        .type('2019-12-31')
       cy.get(
         '[data-testid="attribute-document-tracking-revision_history-0-date"] input[type="time"]'
       )
-        .type('13:41')
+        .type('12:01')
       cy.get(
         '[data-testid="attribute-document-tracking-revision_history-0-number"] input'
       )
         .clear()
-        .type('1.0.0')
+        .type('0.9.0')
 
       // create second revision history item
       cy.get(
@@ -836,13 +836,34 @@ describe('SecvisogramPage / FormEditor Tab', function () {
       cy.get(
         '[data-testid="attribute-document-tracking-revision_history-1-date"] input[type="date"]'
       )
-        .type('2021-02-01')
+        .type('2020-02-01')
       cy.get(
         '[data-testid="attribute-document-tracking-revision_history-1-date"] input[type="time"]'
       )
-        .type('13:15')
+        .type('13:41')
       cy.get(
         '[data-testid="attribute-document-tracking-revision_history-1-number"] input'
+      )
+        .clear()
+        .type('1.0.0')
+
+      // create third revision history item
+      cy.get(
+        '[data-testid="menu_entry-/document/tracking/revision_history-add_item_button"]'
+      ).click({ force: true })
+      cy.get(
+        '[data-testid="menu_entry-/document/tracking/revision_history/2"]'
+      ).click()
+      cy.get(
+        '[data-testid="attribute-document-tracking-revision_history-2-date"] input[type="date"]'
+      )
+        .type('2021-02-01')
+      cy.get(
+        '[data-testid="attribute-document-tracking-revision_history-2-date"] input[type="time"]'
+      )
+        .type('13:15')
+      cy.get(
+        '[data-testid="attribute-document-tracking-revision_history-2-number"] input'
       )
         .clear()
         .type('1.5.0')

--- a/app/cypress/e2e/SecvisogramPage/FormEditorTab.cy.js
+++ b/app/cypress/e2e/SecvisogramPage/FormEditorTab.cy.js
@@ -611,7 +611,7 @@ describe('SecvisogramPage / FormEditor Tab', function () {
   describe('fill functions for revision history', function () {
     it('fill date of revision', function () {
       cy.visit('?tab=EDITOR')
-      const now = new Date(2020, 0, 1, 10, 30)
+      const now = new Date(2020, 1, 1, 10, 30)
       cy.clock(now)
 
       // create new revision history item
@@ -637,7 +637,7 @@ describe('SecvisogramPage / FormEditor Tab', function () {
       ).click()
       cy.get(
         '[data-testid="attribute-document-tracking-revision_history-0-date"] input[type="date"]'
-      ).should('have.value', '2020-01-01')
+      ).should('have.value', '2020-02-01')
       cy.get(
         '[data-testid="attribute-document-tracking-revision_history-0-date"] input[type="time"]'
       ).should('have.value', '11:00')
@@ -648,7 +648,7 @@ describe('SecvisogramPage / FormEditor Tab', function () {
       ).click()
       cy.get(
         '[data-testid="attribute-document-tracking-revision_history-0-date"] input[type="date"]'
-      ).should('have.value', '2020-01-01')
+      ).should('have.value', '2020-02-01')
       cy.get(
         '[data-testid="attribute-document-tracking-revision_history-0-date"] input[type="time"]'
       ).should('have.value', '11:00')
@@ -687,7 +687,7 @@ describe('SecvisogramPage / FormEditor Tab', function () {
       cy.get(
         '[data-testid="attribute-document-tracking-revision_history-0-date"] input[type="date"]'
       )
-        .type('2020-01-01')
+        .type('2020-02-01')
       cy.get(
         '[data-testid="attribute-document-tracking-revision_history-0-date"] input[type="time"]'
       )
@@ -708,7 +708,7 @@ describe('SecvisogramPage / FormEditor Tab', function () {
       ).click()
       cy.get(
         '[data-testid="attribute-document-tracking-current_release_date"] input[type="date"]'
-      ).should('have.value', '2020-01-01')
+      ).should('have.value', '2020-02-01')
       cy.get(
         '[data-testid="attribute-document-tracking-current_release_date"] input[type="time"]'
       ).should('have.value', '13:41')
@@ -719,7 +719,7 @@ describe('SecvisogramPage / FormEditor Tab', function () {
       ).click()
       cy.get(
         '[data-testid="attribute-document-tracking-current_release_date"] input[type="date"]'
-      ).should('have.value', '2020-01-01')
+      ).should('have.value', '2020-02-01')
       cy.get(
         '[data-testid="attribute-document-tracking-current_release_date"] input[type="time"]'
       ).should('have.value', '13:41')
@@ -758,7 +758,7 @@ describe('SecvisogramPage / FormEditor Tab', function () {
       cy.get(
         '[data-testid="attribute-document-tracking-revision_history-0-date"] input[type="date"]'
       )
-        .type('2020-01-01')
+        .type('2020-02-01')
       cy.get(
         '[data-testid="attribute-document-tracking-revision_history-0-date"] input[type="time"]'
       )
@@ -784,7 +784,7 @@ describe('SecvisogramPage / FormEditor Tab', function () {
       ).click()
       cy.get(
         '[data-testid="attribute-document-tracking-initial_release_date"] input[type="date"]'
-      ).should('have.value', '2020-01-01')
+      ).should('have.value', '2020-02-01')
       cy.get(
         '[data-testid="attribute-document-tracking-initial_release_date"] input[type="time"]'
       ).should('have.value', '13:41')
@@ -795,7 +795,7 @@ describe('SecvisogramPage / FormEditor Tab', function () {
       ).click()
       cy.get(
         '[data-testid="attribute-document-tracking-initial_release_date"] input[type="date"]'
-      ).should('have.value', '2020-01-01')
+      ).should('have.value', '2020-02-01')
       cy.get(
         '[data-testid="attribute-document-tracking-initial_release_date"] input[type="time"]'
       ).should('have.value', '13:41')
@@ -815,7 +815,7 @@ describe('SecvisogramPage / FormEditor Tab', function () {
       cy.get(
         '[data-testid="attribute-document-tracking-revision_history-0-date"] input[type="date"]'
       )
-        .type('2020-01-01')
+        .type('2020-02-01')
       cy.get(
         '[data-testid="attribute-document-tracking-revision_history-0-date"] input[type="time"]'
       )
@@ -836,7 +836,7 @@ describe('SecvisogramPage / FormEditor Tab', function () {
       cy.get(
         '[data-testid="attribute-document-tracking-revision_history-1-date"] input[type="date"]'
       )
-        .type('2021-01-01')
+        .type('2021-02-01')
       cy.get(
         '[data-testid="attribute-document-tracking-revision_history-1-date"] input[type="time"]'
       )
@@ -854,7 +854,7 @@ describe('SecvisogramPage / FormEditor Tab', function () {
       ).click()
       cy.get(
         '[data-testid="attribute-document-tracking-initial_release_date"] input[type="date"]'
-      ).should('have.value', '2020-01-01')
+      ).should('have.value', '2020-02-01')
       cy.get(
         '[data-testid="attribute-document-tracking-initial_release_date"] input[type="time"]'
       ).should('have.value', '13:41')
@@ -865,7 +865,7 @@ describe('SecvisogramPage / FormEditor Tab', function () {
       ).click()
       cy.get(
         '[data-testid="attribute-document-tracking-current_release_date"] input[type="date"]'
-      ).should('have.value', '2021-01-01')
+      ).should('have.value', '2021-02-01')
       cy.get(
         '[data-testid="attribute-document-tracking-current_release_date"] input[type="time"]'
       ).should('have.value', '13:15')

--- a/app/lib/app/SecvisogramPage/View/FormEditor/editors/GenericEditor.js
+++ b/app/lib/app/SecvisogramPage/View/FormEditor/editors/GenericEditor.js
@@ -1,3 +1,4 @@
+import { faClock } from '@fortawesome/free-solid-svg-icons'
 import { t } from 'i18next'
 import React from 'react'
 import AppConfigContext from '../../../../shared/context/AppConfigContext.js'
@@ -6,6 +7,9 @@ import UserInfoContext from '../../../../shared/context/UserInfoContext.js'
 import DocumentEditorContext from '../../shared/DocumentEditorContext.js'
 import {
   getBranchName,
+  getCurrentDateRounded,
+  getCurrentReleaseDate,
+  getInitialReleaseDate,
   getRelationshipName,
   uniqueProductId,
 } from '../shared/fillFieldFunctions.js'
@@ -112,17 +116,24 @@ export default function Editor({
           updateDoc(instancePath, getBranchName(doc, instancePath.slice(0, -1)))
         }
       : uiType === 'STRING_RELATIONSHIP_FULL_PRODUCT_NAME'
-      ? () => {
+      ? () =>
           getRelationshipName(doc, instancePath, collectIds['productIds']).then(
             (r) => updateDoc(instancePath, r),
             handleError
           )
-        }
+      : property.key === 'date'
+      ? () => updateDoc(instancePath, getCurrentDateRounded())
+      : property.key === 'current_release_date'
+      ? () => updateDoc(instancePath, getCurrentReleaseDate(doc))
+      : property.key === 'initial_release_date'
+      ? () => updateDoc(instancePath, getInitialReleaseDate(doc))
       : undefined
 
   const fillDefaultFunction = () => {
     if (property.default) updateDoc(instancePath, property.default)
   }
+
+  const fillFunctionIcon = property.key === 'date' ? faClock : undefined
 
   if (property.type === 'ARRAY') {
     return (
@@ -178,6 +189,8 @@ export default function Editor({
           value={value || ''}
           property={property}
           disabled={disabled}
+          fillFunction={fillFunction}
+          fillFunctionIcon={fillFunctionIcon}
         />
       ))
     } else if (uiType === 'STRING_ENUM') {

--- a/app/lib/app/SecvisogramPage/View/FormEditor/editors/GenericEditor/Attributes/DateAttribute.js
+++ b/app/lib/app/SecvisogramPage/View/FormEditor/editors/GenericEditor/Attributes/DateAttribute.js
@@ -13,6 +13,9 @@ import pruneEmpty from '../../../../../../shared/pruneEmpty.js'
  *  value: unknown
  *  property: import('../../../shared/types').Property
  *  disabled: boolean
+ *  fillFunction?: () => void
+ *  fillDefaultFunction?: () => void
+ *  fillFunctionIcon?: import('@fortawesome/fontawesome-svg-core').IconProp
  * }} props
  */
 export default function DateAttribute({

--- a/app/lib/app/SecvisogramPage/View/FormEditor/editors/GenericEditor/Attributes/shared/Attribute.js
+++ b/app/lib/app/SecvisogramPage/View/FormEditor/editors/GenericEditor/Attributes/shared/Attribute.js
@@ -26,6 +26,7 @@ import AttributeErrors from './AttributeErrors.js'
  *  disabled: boolean
  *  fillFunction?: () => void
  *  fillDefaultFunction?: () => void
+ *  fillFunctionIcon?: import('@fortawesome/fontawesome-svg-core').IconProp
  * }} props
  * @template V
  */
@@ -38,6 +39,7 @@ export default function Attribute({
   disabled,
   fillFunction,
   fillDefaultFunction,
+  fillFunctionIcon,
 }) {
   const { errors, doc } = React.useContext(DocumentEditorContext)
   const { selectedRelevanceLevel, relevanceLevels } = React.useContext(
@@ -124,7 +126,7 @@ export default function Attribute({
             className="w-6 h-6 flex-none text-slate-400 hover:text-slate-800 m-1"
             onClick={fillFunction}
           >
-            <FontAwesomeIcon icon={faMagic} />
+            <FontAwesomeIcon icon={fillFunctionIcon ?? faMagic} />
           </button>
         ) : null}
       </div>

--- a/app/lib/app/SecvisogramPage/View/FormEditor/shared/fillFieldFunctions.js
+++ b/app/lib/app/SecvisogramPage/View/FormEditor/shared/fillFieldFunctions.js
@@ -86,4 +86,52 @@ const getRelationshipName = async function (
   throw Error('Could not find relationship to generate name from.')
 }
 
-export { uniqueProductId, uniqueGroupId, getBranchName, getRelationshipName }
+/**
+ * function to get the current Date rounded to the next full hour
+ *
+ * @return string|undefined
+ */
+const getCurrentDateRounded = function () {
+  const p = 60 * 60 * 1000 // milliseconds in an hour
+  const roundedDate = new Date(Math.ceil(new Date().getTime() / p) * p)
+  return roundedDate.toISOString()
+}
+
+/**
+ * function to extract current release date from revision history
+ *
+ * @param {Record<string, any>} doc
+ * @return string|undefined
+ */
+const getCurrentReleaseDate = function (doc) {
+  /** @type {{date: string, number: string}[]} */
+  const revisionHistory = doc?.document?.tracking?.revision_history
+  return revisionHistory
+    ?.map((x) => x.date)
+    .sort()
+    .reverse()?.[0]
+}
+
+/**
+ * function to extract initial release date from revision history
+ *
+ * @param {Record<string, any>} doc
+ * @return string|undefined
+ */
+const getInitialReleaseDate = function (doc) {
+  /** @type {{date: string, number: string}[]} */
+  const revisionHistory = doc?.document?.tracking?.revision_history
+  return revisionHistory?.filter(
+    (x) => x.number === '1' || x.number === '1.0.0'
+  )?.[0]?.date
+}
+
+export {
+  uniqueProductId,
+  uniqueGroupId,
+  getBranchName,
+  getRelationshipName,
+  getCurrentDateRounded,
+  getCurrentReleaseDate,
+  getInitialReleaseDate,
+}


### PR DESCRIPTION
# Fillfunctions in /document/tracking

## Changes
1. Add fill function for `Date of revision` (Clock icon) in Tracking/RevisionHistory/*/
2. Add fill function for `current_release_date` in Tracking/Fields
3. Add fill function for `initial_release_date` in Tracking/Fields

## Steps to test
- In FormEditor navigate to Tracking
- Add new Revision history Item (3 dots, "Add list item")
  - Set Version to 1.0.0
  - Set date e.g. 01.01.2020
- Add second Revision history Item
  - Set Version later than 1 e.g. 2.0.0
  - Set current date with clock icon (should enter current date and time rounded to next hour)
- Navigate to Tracking/Fields
  - Set initial release and current release with fill functions (magic wand icon)
  - Both should be filled with the previously set values