### PR TITLE
feat: add github action for sbom generation

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           path: .
           format: spdx-json
-          artifact-name: sbom.secvisogram_spdx.json
+          artifact-name: sbom.secvisogram.spdx.json
 
   cyclonedx:
     name: "CycloneDX SBOM generation"

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,30 @@
+name: "SBOM generation"
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  spdx:
+    name: "SPDX SBOM generation"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: anchore/sbom-action@v0
+        with:
+          path: .
+          format: spdx-json
+          artifact-name: sbom.secvisogram_spdx.json
+
+  cyclonedx:
+    name: "CycloneDX SBOM generation"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: anchore/sbom-action@v0
+        with:
+          path: .
+          format: cyclonedx-json
+          artifact-name: sbom.secvisogram_cyclonedx.json

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -27,4 +27,4 @@ jobs:
         with:
           path: .
           format: cyclonedx-json
-          artifact-name: sbom.secvisogram_cyclonedx.json
+          artifact-name: sbom.secvisogram.cdx.json


### PR DESCRIPTION
# Behavior
Every release triggers the github action which uses [Syft](https://github.com/anchore/syft) to generate sbom files in both `SPDX` and `CycloneDX` formats. The generated json files will then be added to the release.

# Prerequisites
Github action needs write permission in order to add the generated files to the release