### PR TITLE
fix: href-clickable

### DIFF
--- a/app/cypress/e2e/SecvisogramPage/SecureHref.cy.js
+++ b/app/cypress/e2e/SecvisogramPage/SecureHref.cy.js
@@ -8,7 +8,9 @@ describe('secureHrefTests', () => {
     it(test.title ?? `Test #${i + 1}`, () => {
       const preview = new DocumentEntity().preview({ document: test.content })
       const html = HTMLTemplate(preview)
-      const hasHref = html.match(/<a href=".*test\.org.*">.*<\/a>/)
+      // during HTML generation some characters are being replaced, so they are being replaced here as well
+      const url = test.url.replaceAll('/', '&#x2F;').replaceAll('=', '&#x3D;')
+      const hasHref = html.match(new RegExp(`<a href="${url}">.*</a>`))
       expect(hasHref !== null).to.equal(test.valid)
     })
   })

--- a/app/cypress/e2e/SecvisogramPage/SecureHref.cy.js
+++ b/app/cypress/e2e/SecvisogramPage/SecureHref.cy.js
@@ -1,0 +1,15 @@
+import { expect } from 'chai'
+import HTMLTemplate from '../../../lib/app/SecvisogramPage/View/shared/HTMLTemplate.js'
+import DocumentEntity from '../../../lib/app/shared/Core/entities/DocumentEntity.js'
+import secureHrefTests from '../../fixtures/secureHrefTests.js'
+
+describe('secureHrefTests', () => {
+  secureHrefTests.forEach((test, i) => {
+    it(test.title ?? `Test #${i + 1}`, () => {
+      const preview = new DocumentEntity().preview({ document: test.content })
+      const html = HTMLTemplate(preview)
+      const hasHref = html.match(/<a href=".*test\.org.*">.*<\/a>/)
+      expect(hasHref !== null).to.equal(test.valid)
+    })
+  })
+})

--- a/app/cypress/fixtures/secureHrefTests.js
+++ b/app/cypress/fixtures/secureHrefTests.js
@@ -1,0 +1,127 @@
+import minimalDoc from './documentTests/shared/minimalDoc.js'
+
+export default [
+  // Valid tests
+  {
+    title: '# href (valid)',
+    valid: true,
+    content: {
+      document: {
+        ...minimalDoc.document,
+        acknowledgments: [{ urls: ['#test.org'] }],
+      },
+    },
+  },
+  {
+    title: 'http href (valid)',
+    valid: true,
+    content: {
+      document: {
+        ...minimalDoc.document,
+        acknowledgments: [{ urls: ['http://test.org'] }],
+      },
+    },
+  },
+  {
+    title: 'https href (valid)',
+    valid: true,
+    content: {
+      document: {
+        ...minimalDoc.document,
+        acknowledgments: [{ urls: ['https://test.org'] }],
+      },
+    },
+  },
+  {
+    title: 'mailto href (valid)',
+    valid: true,
+    content: {
+      document: {
+        ...minimalDoc.document,
+        acknowledgments: [{ urls: ['mailto://user@test.org'] }],
+      },
+    },
+  },
+  {
+    title: 'tel href (valid)',
+    valid: true,
+    content: {
+      document: {
+        ...minimalDoc.document,
+        acknowledgments: [{ urls: ['tel://+4934587913248test.org'] }],
+      },
+    },
+  },
+  {
+    title: 'ftp href (valid)',
+    valid: true,
+    content: {
+      document: {
+        ...minimalDoc.document,
+        acknowledgments: [{ urls: ['ftp://test.org'] }],
+      },
+    },
+  },
+  {
+    title: 'data href (MIME-type png) (valid)',
+    valid: true,
+    content: {
+      document: {
+        ...minimalDoc.document,
+        acknowledgments: [{ urls: ['data:image/png;base64,iVBORwtest.org0KGgoAAAANSUhEUgAAA'] }],
+      },
+    },
+  },
+  {
+    title: 'data href (MIME-type jpeg) (valid)',
+    valid: true,
+    content: {
+      document: {
+        ...minimalDoc.document,
+        acknowledgments: [{ urls: ['data:image/jpeg;base64,iVBORw0KGgoAtest.orgAAANSUhEUgAAA'] }],
+      },
+    },
+  },
+
+  // invalid tests
+  {
+    title: 'sftp href (invalid)',
+    valid: false,
+    content: {
+      document: {
+        ...minimalDoc.document,
+        acknowledgments: [{ urls: ['sftp://test.org'] }],
+      },
+    },
+  },
+  {
+    title: 'ws href (invalid)',
+    valid: false,
+    content: {
+      document: {
+        ...minimalDoc.document,
+        acknowledgments: [{ urls: ['ws://test.org'] }],
+      },
+    },
+  },
+  {
+    title: 'wss href (invalid)',
+    valid: false,
+    content: {
+      document: {
+        ...minimalDoc.document,
+        acknowledgments: [{ urls: ['wss://test.org'] }],
+      },
+    },
+  },
+  {
+    title: 'data href (MIME-type gif) (invalid)',
+    valid: false,
+    content: {
+      document: {
+        ...minimalDoc.document,
+        acknowledgments: [{ urls: ['data:image/gif;base64,iVBORw0Ktest.orgGgoAAAANSUhEUgAAA'] }],
+      },
+    },
+  },
+]

--- a/app/cypress/fixtures/secureHrefTests.js
+++ b/app/cypress/fixtures/secureHrefTests.js
@@ -5,80 +5,129 @@ export default [
   {
     title: '# href (valid)',
     valid: true,
+    url: '#example.com',
     content: {
       document: {
         ...minimalDoc.document,
-        acknowledgments: [{ urls: ['#test.org'] }],
+        acknowledgments: [{ urls: ['#example.com'] }],
       },
     },
   },
   {
     title: 'http href (valid)',
     valid: true,
+    url: 'http://example.com',
     content: {
       document: {
         ...minimalDoc.document,
-        acknowledgments: [{ urls: ['http://test.org'] }],
+        acknowledgments: [{ urls: ['http://example.com'] }],
       },
     },
   },
   {
     title: 'https href (valid)',
     valid: true,
+    url: 'https://example.com',
     content: {
       document: {
         ...minimalDoc.document,
-        acknowledgments: [{ urls: ['https://test.org'] }],
+        acknowledgments: [{ urls: ['https://example.com'] }],
       },
     },
   },
   {
     title: 'mailto href (valid)',
     valid: true,
+    url: 'mailto:user@example.com',
     content: {
       document: {
         ...minimalDoc.document,
-        acknowledgments: [{ urls: ['mailto://user@test.org'] }],
+        acknowledgments: [{ urls: ['mailto:user@example.com'] }],
+      },
+    },
+  },
+  {
+    title: 'mailto href with slashes (valid)',
+    valid: true,
+    url: 'mailto://user@example.com',
+    content: {
+      document: {
+        ...minimalDoc.document,
+        acknowledgments: [{ urls: ['mailto://user@example.com'] }],
       },
     },
   },
   {
     title: 'tel href (valid)',
     valid: true,
+    url: 'tel:\\+493023125000',
     content: {
       document: {
         ...minimalDoc.document,
-        acknowledgments: [{ urls: ['tel://+4934587913248test.org'] }],
+        acknowledgments: [{ urls: ['tel:+493023125000'] }],
+      },
+    },
+  },
+  {
+    title: 'tel href with slashes (valid)',
+    valid: true,
+    url: 'tel://\\+493023125000',
+    content: {
+      document: {
+        ...minimalDoc.document,
+        acknowledgments: [{ urls: ['tel://+493023125000'] }],
       },
     },
   },
   {
     title: 'ftp href (valid)',
     valid: true,
+    url: 'ftp://example.com',
     content: {
       document: {
         ...minimalDoc.document,
-        acknowledgments: [{ urls: ['ftp://test.org'] }],
+        acknowledgments: [{ urls: ['ftp://example.com'] }],
       },
     },
   },
   {
     title: 'data href (MIME-type png) (valid)',
     valid: true,
+    url: 'data:image/png;base64,dGVzdA==',
     content: {
       document: {
         ...minimalDoc.document,
-        acknowledgments: [{ urls: ['data:image/png;base64,iVBORwtest.org0KGgoAAAANSUhEUgAAA'] }],
+        acknowledgments: [
+          {
+            urls: ['data:image/png;base64,dGVzdA=='],
+          },
+        ],
       },
     },
   },
   {
     title: 'data href (MIME-type jpeg) (valid)',
     valid: true,
+    url: 'data:image/jpeg;base64,dGVzdA==',
     content: {
       document: {
         ...minimalDoc.document,
-        acknowledgments: [{ urls: ['data:image/jpeg;base64,iVBORw0KGgoAtest.orgAAANSUhEUgAAA'] }],
+        acknowledgments: [
+          {
+            urls: ['data:image/jpeg;base64,dGVzdA=='],
+          },
+        ],
+      },
+    },
+  },
+  {
+    title: 'data href (MIME-type gif) (valid)',
+    valid: true,
+    url: 'data:image/gif;base64,dGVzdA==',
+    content: {
+      document: {
+        ...minimalDoc.document,
+        acknowledgments: [{ urls: ['data:image/gif;base64,dGVzdA=='] }],
       },
     },
   },
@@ -87,40 +136,59 @@ export default [
   {
     title: 'sftp href (invalid)',
     valid: false,
+    url: 'sftp://example.com',
     content: {
       document: {
         ...minimalDoc.document,
-        acknowledgments: [{ urls: ['sftp://test.org'] }],
+        acknowledgments: [{ urls: ['sftp://example.com'] }],
       },
     },
   },
   {
     title: 'ws href (invalid)',
     valid: false,
+    url: 'ws://example.com',
     content: {
       document: {
         ...minimalDoc.document,
-        acknowledgments: [{ urls: ['ws://test.org'] }],
+        acknowledgments: [{ urls: ['ws://example.com'] }],
       },
     },
   },
   {
     title: 'wss href (invalid)',
     valid: false,
+    url: 'wss://example.com',
     content: {
       document: {
         ...minimalDoc.document,
-        acknowledgments: [{ urls: ['wss://test.org'] }],
+        acknowledgments: [{ urls: ['wss://example.com'] }],
       },
     },
   },
   {
-    title: 'data href (MIME-type gif) (invalid)',
+    title: 'data href (MIME-type svg) (invalid)',
     valid: false,
+    url: 'data:image/svg\\+xml;base64,dGVzdA==',
     content: {
       document: {
         ...minimalDoc.document,
-        acknowledgments: [{ urls: ['data:image/gif;base64,iVBORw0Ktest.orgGgoAAAANSUhEUgAAA'] }],
+        acknowledgments: [{ urls: ['data:image/svg+xml;base64,dGVzdA=='] }],
+      },
+    },
+  },
+  {
+    title: 'data href (MIME-type png) with invalid base64 (invalid)',
+    valid: false,
+    url: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAA',
+    content: {
+      document: {
+        ...minimalDoc.document,
+        acknowledgments: [
+          {
+            urls: ['data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAA'],
+          },
+        ],
       },
     },
   },

--- a/app/lib/app/SecvisogramPage/View/shared/HTMLTemplate.js
+++ b/app/lib/app/SecvisogramPage/View/shared/HTMLTemplate.js
@@ -35,8 +35,8 @@ const REMEDIATION = `
    <li>{{name}}</li>
   {{/group_ids}}
   </ul>
-{{/group_ids.length}}        
-{{#url}}<p><a href={{.}}>{{.}}</a></p>{{/url}}
+{{/group_ids.length}}
+<p>{{#url}}{{> url }}{{/url}}</p>
 {{#entitlements}}
   <p>{{.}}</p>
 {{/entitlements}}
@@ -75,13 +75,19 @@ const DOCUMENT_NOTE = `
 {{#text}}<p>{{text}}</p>{{/text}}`
 const ACKNOWLEDGEMENT = `
 {{#.}}
-  <li>{{#removeTrailingComma}}{{#names}}{{.}}, {{/names}}{{/removeTrailingComma}}{{#organization}}{{#names.length}} from {{/names.length}}{{.}} {{/organization}}{{#summary}} for {{.}}{{/summary}}{{#urls.length}} (see: {{#removeTrailingComma}}{{#urls}}<a href={{.}}>{{.}}</a>, {{/urls}}{{/removeTrailingComma}}){{/urls.length}}</li>  
+  <li>{{#removeTrailingComma}}{{#names}}{{.}}, {{/names}}{{/removeTrailingComma}}{{#organization}}{{#names.length}} from {{/names.length}}{{.}} {{/organization}}{{#summary}} for {{.}}{{/summary}}{{#urls.length}} (see: {{#removeTrailingComma}}{{#urls}}{{> url}}, {{/urls}}{{/removeTrailingComma}}){{/urls.length}}</li>
 {{/.}}`
 
 const REFERENCE = `
 {{#.}}
-  <li>{{summary}} {{#category}} ({{#replaceUnderscores}}{{.}}{{/replaceUnderscores}}){{/category}}{{#url}}: <a href={{.}}>{{.}}</a>{{/url}}</li>
+  <li>{{summary}} {{#category}} ({{#replaceUnderscores}}{{.}}{{/replaceUnderscores}}){{/category}}{{#url}}{{> url}}{{/url}}</li>
 {{/.}}`
+
+const URL = `
+{{#.}}
+  <a {{#secureHref}}{{.}}{{/secureHref}}>{{.}}</a>
+{{/.}}
+`
 
 /**
  * Encapsulates the rendering of the mustache template.
@@ -98,5 +104,6 @@ export default function HTMLTemplate({ document }) {
     document_note: DOCUMENT_NOTE,
     acknowledgment: ACKNOWLEDGEMENT,
     reference: REFERENCE,
+    url: URL,
   })
 }

--- a/app/lib/app/SecvisogramPage/View/shared/HTMLTemplate/Template.html
+++ b/app/lib/app/SecvisogramPage/View/shared/HTMLTemplate/Template.html
@@ -331,7 +331,7 @@
     <p>
       {{#tlp}}
         <b>{{#label}}TLP:{{.}}{{/label}}</b><br>
-        For the TLP version see: <a {{#secureHref}}{{#url}}{{.}}{{/url}}{{/secureHref}}{{^url}}https://www.first.org/tlp/{{/url}}>{{#url}}{{.}}{{/url}}{{^url}}https://www.first.org/tlp/{{/url}}</a>
+        For the TLP version see: <a {{#secureHref}}{{#url}}{{.}}{{/url}}{{/secureHref}}{{^url}}href=https://www.first.org/tlp/{{/url}}>{{#url}}{{.}}{{/url}}{{^url}}https://www.first.org/tlp/{{/url}}</a>
       {{/tlp}}
     </p>
     <p>{{text}}</p>

--- a/app/lib/app/SecvisogramPage/View/shared/HTMLTemplate/Template.html
+++ b/app/lib/app/SecvisogramPage/View/shared/HTMLTemplate/Template.html
@@ -25,12 +25,12 @@
     </tr>
     <tr>
       <td>Current version: {{document.tracking.version}}</td>
-      <td>Status: {{document.tracking.status}}</td>    
+      <td>Status: {{document.tracking.status}}</td>
     </tr>
     <tr>
       <td>CVSSv3.1 Base Score: {{document.max_base_score}}</td>
       <td>Severity:
-        {{#document.aggregate_severity.namespace}} <a href={{document.aggregate_severity.namespace}}>{{document.aggregate_severity.text}}</a>{{/document.aggregate_severity.namespace}}
+        {{#document.aggregate_severity.namespace}} <a {{#secureHref}}{{document.aggregate_severity.namespace}}{{/secureHref}}>{{document.aggregate_severity.text}}</a>{{/document.aggregate_severity.namespace}}
         {{^document.aggregate_severity.namespace}} {{document.aggregate_severity.text}}{{/document.aggregate_severity.namespace}}
       </td>
     </tr>
@@ -40,7 +40,7 @@
     </tr>
     <tr>
       <td colspan="2">Also referred to: {{#removeTrailingComma}}{{#document.tracking.aliases}}{{.}}, {{/document.tracking.aliases}}{{/removeTrailingComma}}</td>
-    </tr>    
+    </tr>
   </table>
 
   {{#document.notes_summary}}
@@ -70,7 +70,7 @@
     {{#product_ids}}
       <li>{{name}}</li>
     {{/product_ids}}
-    </ul>    
+    </ul>
   {{/product_tree.product_groups}}
   {{/product_tree.product_groups.length}}
 
@@ -121,10 +121,10 @@
         <tr>
           <th>Release date:</th>
           <td>{{release_date}}</td>
-        </tr>            
+        </tr>
       {{/release_date}}
     </table>
-    
+
     <h4>Product status</h4>
     {{#product_status.known_affected.length}}
     <h5>Known affected</h5>
@@ -155,7 +155,7 @@
     <table>
       {{> product_status_header}}
       <tbody>
-        {{#product_status.last_affected}}    
+        {{#product_status.last_affected}}
           {{> product_status_row}}
         {{/product_status.last_affected}}
       </tbody>
@@ -170,7 +170,7 @@
       {{/product_status.known_not_affected}}
     </ul>
     {{/product_status.known_not_affected.length}}
-    
+
     {{#product_status.recommended.length}}
     <h5>Recommended</h5>
     <ul>
@@ -179,7 +179,7 @@
       {{/product_status.recommended}}
     </ul>
     {{/product_status.recommended.length}}
-    
+
     {{#product_status.fixed.length}}
     <h5>Fixed</h5>
     <ul>
@@ -223,23 +223,23 @@
       {{/remediations_none_available}}
       {{#remediations_no_fix_planned}}
         {{> remediation}}
-      {{/remediations_no_fix_planned}}                        
+      {{/remediations_no_fix_planned}}
       {{#remediations_unknown}}
         {{> remediation}}
-      {{/remediations_unknown}}                              
+      {{/remediations_unknown}}
     {{/remediations.length}}
 
     {{#acknowledgments.length}}
     <h4>Acknowledgments</h4>
     <ul>
-    {{#acknowledgments}}      
+    {{#acknowledgments}}
       {{> acknowledgment}}
     {{/acknowledgments}}
     </ul>
     {{/acknowledgments.length}}
 
     {{#involvements.length}}
-      <h4>Involvement</h4>      
+      <h4>Involvement</h4>
       <ul>
       {{#involvements}}
         {{#.}}
@@ -280,7 +280,7 @@
   <h2>Acknowledgments</h2>
   {{document.publisher.name}} thanks the following parties for their efforts:
   <ul>
-  {{#document.acknowledgments}}      
+  {{#document.acknowledgments}}
     {{> acknowledgment}}
   {{/document.acknowledgments}}
   </ul>
@@ -331,7 +331,7 @@
     <p>
       {{#tlp}}
         <b>{{#label}}TLP:{{.}}{{/label}}</b><br>
-        For the TLP version see: <a href={{#url}}{{.}}{{/url}}{{^url}}https://www.first.org/tlp/{{/url}}>{{#url}}{{.}}{{/url}}{{^url}}https://www.first.org/tlp/{{/url}}</a>
+        For the TLP version see: <a {{#secureHref}}{{#url}}{{.}}{{/url}}{{/secureHref}}{{^url}}https://www.first.org/tlp/{{/url}}>{{#url}}{{.}}{{/url}}{{^url}}https://www.first.org/tlp/{{/url}}</a>
       {{/tlp}}
     </p>
     <p>{{text}}</p>

--- a/app/lib/app/shared/Core/entities/DocumentEntity.js
+++ b/app/lib/app/shared/Core/entities/DocumentEntity.js
@@ -272,14 +272,22 @@ export default class DocumentEntity {
         let isValid = false
 
         const validStarts = ['#', 'mailto', 'tel', 'http', 'ftp']
-        const validMimeTypes = ['image/png;base64', 'image/jpeg;base64'].map((x) =>
-          x.replaceAll('/', '&#x2F;')
-        )
+        const validMimeTypes = [
+          'image/png;base64,',
+          'image/jpeg;base64,',
+          'image/gif;base64,',
+        ].map((x) => x.replaceAll('/', '&#x2F;'))
         validStarts.forEach((x) => (isValid = isValid || href.startsWith(x)))
-        validMimeTypes.forEach(
-          (mimeType) =>
-            (isValid = isValid || href.startsWith(`data:${mimeType}`))
-        )
+        const isBase64 = (/** @type {string} */ value) =>
+          /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$/.test(
+            value
+          )
+        validMimeTypes.forEach((mimeType) => {
+          const isValidDataHref =
+            href.startsWith(`data:${mimeType}`) &&
+            isBase64(href.split(',')[1]?.replaceAll('&#x3D;', '='))
+          isValid = isValid || isValidDataHref
+        })
 
         return isValid ? `href="${href}"` : ''
       }

--- a/app/lib/app/shared/Core/entities/DocumentEntity.js
+++ b/app/lib/app/shared/Core/entities/DocumentEntity.js
@@ -263,6 +263,28 @@ export default class DocumentEntity {
       }
     }
 
+    templateDoc.secureHref = () => {
+      return function (
+        /** @type {string} */ text,
+        /** @type {function} */ render
+      ) {
+        const href = render(text)
+        let isValid = false
+
+        const validStarts = ['#', 'mailto', 'tel', 'http', 'ftp']
+        const validMimeTypes = ['image/png;base64', 'image/jpeg;base64'].map((x) =>
+          x.replaceAll('/', '&#x2F;')
+        )
+        validStarts.forEach((x) => (isValid = isValid || href.startsWith(x)))
+        validMimeTypes.forEach(
+          (mimeType) =>
+            (isValid = isValid || href.startsWith(`data:${mimeType}`))
+        )
+
+        return isValid ? `href="${href}"` : ''
+      }
+    }
+
     return { document: templateDoc }
   }
 }


### PR DESCRIPTION
# Changes
HTML rendering was adjusted so that `<a>` tags are only clickable if one of the following conditions apply:
- The url starts with `#`, `mailto`, `tel`, `http` or `ftp`
- The url starts with `data` and has mimetype for `png` or `jpeg`
