### PR TITLE
fix: json editor does not update on file reload

### DIFF
--- a/app/cypress/e2e/SecvisogramPage/JsonEditorTab.cy.js
+++ b/app/cypress/e2e/SecvisogramPage/JsonEditorTab.cy.js
@@ -1,4 +1,5 @@
 import sortObjectKeys from '../../../lib/app/shared/sortObjectKeys.js'
+import minimalDoc from '../../fixtures/documentTests/shared/minimalDoc.js'
 
 describe('SecvisogramPage / JsonEditorTab', function () {
   it('can change a document and load changes', function () {
@@ -75,5 +76,65 @@ describe('SecvisogramPage / JsonEditorTab', function () {
         JSON.stringify(this.sortedEditorValue, null, 2)
       )
     })
+  })
+
+  it('editor updates on file load', function () {
+    cy.intercept('/.well-known/appspecific/de.bsi.secvisogram.json', {
+      statusCode: 404,
+    }).as('wellKnownAppConfig')
+    const fileURL = 'https://example.com/test.json'
+    cy.intercept(fileURL, {
+      body: minimalDoc,
+    })
+
+    const loadDocument = () => {
+      cy.get('[data-testid="new_document_button"]').click()
+      cy.get('[data-testid="new_document-url_button"]').click()
+      cy.get('[data-testid="new_document-url_input"]').type(fileURL)
+      cy.get('[data-testid="new_document-create_document_button"]').click()
+
+      // click confirm button if it exists
+      cy.get('body')
+        .then(($body) => {
+          return $body.find('[data-testid="alert-confirm_button"]').length
+            ? true
+            : false
+        })
+        .then((confirmationNeeded) => {
+          if (confirmationNeeded) {
+            cy.get('[data-testid="alert-confirm_button"]').click()
+          }
+        })
+    }
+
+    const expectTitle = (/** @type {string} */ title) =>
+      cy.window().should((/** @type {any} */ win) => {
+        expect(Boolean(win.MONACO_EDITOR)).to.be.true
+        const doc = JSON.parse(win.MONACO_EDITOR.getModel().getValue())
+        expect(doc.document.title).to.equal(title)
+      })
+
+    cy.visit('?tab=SOURCE')
+    cy.wait('@wellKnownAppConfig')
+
+    // load test document
+    loadDocument()
+    expectTitle(minimalDoc.document.title)
+
+    // change title
+    const newDocumentTitle = 'a different document title'
+    cy.window().then((/** @type {any} */ win) => {
+      const editor = win.MONACO_EDITOR
+      const value = JSON.parse(editor.getModel().getValue())
+      value.document.title = newDocumentTitle
+      editor.getModel().setValue(JSON.stringify(value, null, 2))
+    })
+    expectTitle(newDocumentTitle)
+
+    // reload test document
+    loadDocument()
+
+    // title change should be undone
+    expectTitle(minimalDoc.document.title)
   })
 })

--- a/app/lib/app/SecvisogramPage/View/JsonEditorTab.js
+++ b/app/lib/app/SecvisogramPage/View/JsonEditorTab.js
@@ -75,21 +75,13 @@ export default function JsonEditorTab({
   }, [sortButtonRef, editor])
 
   /**
-   * The initial value of the state used to prevent a re-render of the ace editor
-   * when the document changes from outside.
-   */
-  const initialValue = React.useMemo(
-    () => JSON.stringify(originalValues.doc, null, 2),
-    [originalValues.doc]
-  )
-  /**
    * Updates the editor value if the document was changed outside (e.g. created from template)
    */
   React.useEffect(() => {
     if (!initialMountRef.current && editor) {
-      editor.getModel()?.setValue(initialValue)
+      editor.getModel()?.setValue(JSON.stringify(originalValues.doc, null, 2))
     }
-  }, [initialValue, editor])
+  }, [originalValues.doc, editor])
 
   const [{ value, parseError }, setState] = React.useState(() => ({
     value: JSON.stringify(doc, null, 2),


### PR DESCRIPTION
Fixes #512 

# Bug cause
JsonEditorTab component used `useMemo` hook to prevent changes from outside.
The `initialValue` was therefore only updated, when the `originalValues` variable was updated and has actually changed. 
This is not the case, when the same file is loaded twice. So due to memoization the `initialValue` variable wasn't updated and the editor wasn't reloaded.

```js
/**
 * The initial value of the state used to prevent a re-render of the ace editor
 * when the document changes from outside.
 */
const initialValue = React.useMemo(
  () => JSON.stringify(originalValues.doc, null, 2),
  [originalValues.doc]
)
```

# Changes
Because the editor was reloaded on initial value change anyway, memoization was just removed.
The new behaviour can cause more component rerenders, but quick testing showed no abnormalities.

Also added test for reloading the same document