### PR TITLE
fix: monacoeditor tooltips hidden by menubar

### DIFF
--- a/app/lib/app/SecvisogramPage/View/JsonEditorTab.js
+++ b/app/lib/app/SecvisogramPage/View/JsonEditorTab.js
@@ -263,9 +263,11 @@ export default function JsonEditorTab({
     }))
   }
 
+  /** @type {import ("react-monaco-editor").monaco.editor.IStandaloneEditorConstructionOptions} */
   const options = {
     selectOnLineNumbers: true,
     automaticLayout: true,
+    fixedOverflowWidgets: true,
   }
   return (
     <>


### PR DESCRIPTION
Fixes #325 

# Changes
The position of the monaco editor popups is now set to `fixed` instead of `absolute`.
This has no visible effect, but the popup is now displayed above the header.