### PR TITLE
feat: product and group id generation enhancement

### DIFF
--- a/app/cypress/e2e/unitTests.cy.js
+++ b/app/cypress/e2e/unitTests.cy.js
@@ -1,14 +1,17 @@
 /// <reference types="cypress" />
 
+import { expect } from 'chai'
 import isPropertyRelevant from '../../lib/app/SecvisogramPage/shared/isPropertyRelevant.js'
 import {
   getBranchName,
+  getNextIdForPrefix,
   getRelationshipName,
-  uniqueGroupId,
-  uniqueProductId,
+  GROUP_PREFIX,
+  PRODUCT_PREFIX,
 } from '../../lib/app/SecvisogramPage/View/FormEditor/shared/fillFieldFunctions.js'
 import pruneEmpty from '../../lib/app/shared/pruneEmpty.js'
 import createFileName from '../../lib/shared/createFileName.js'
+import { testDocuments } from '../fixtures/vulnerabilityFlagsTests.js'
 
 describe('Unit Test Functions', function () {
   context('createFileName.js', function () {
@@ -214,29 +217,14 @@ describe('Unit Test Functions', function () {
   })
 
   context('fillFieldFunctions.js', function () {
-    context('uniqueProductId', function () {
-      it('should produce continuous product IDs', function () {
-        expect(uniqueProductId(false)).to.eq('CSAFPID-0001')
-        expect(uniqueProductId(false)).to.eq('CSAFPID-0002')
-        expect(uniqueProductId(false)).to.eq('CSAFPID-0003')
+    context('getNextIdForPrefix', function () {
+      it('should return next product id', function () {
+        const nextProductId = getNextIdForPrefix(PRODUCT_PREFIX, 'product_id', testDocuments.baseTestDocument)
+        expect(nextProductId).to.eq(3)
       })
-      it('should reset the counter', function () {
-        expect(uniqueProductId(true)).to.eq('CSAFPID-0000')
-        expect(uniqueProductId(true)).to.eq('CSAFPID-0000')
-        expect(uniqueProductId(true)).to.eq('CSAFPID-0000')
-      })
-    })
-
-    context('uniqueGroupId', function () {
-      it('should produce continuous group IDs', function () {
-        expect(uniqueGroupId(false)).to.eq('CSAFGID-0001')
-        expect(uniqueGroupId(false)).to.eq('CSAFGID-0002')
-        expect(uniqueGroupId(false)).to.eq('CSAFGID-0003')
-      })
-      it('should reset the counter', function () {
-        expect(uniqueGroupId(true)).to.eq('CSAFGID-0000')
-        expect(uniqueGroupId(true)).to.eq('CSAFGID-0000')
-        expect(uniqueGroupId(true)).to.eq('CSAFGID-0000')
+      it('should return next group id', function () {
+        const nextGroupId = getNextIdForPrefix(GROUP_PREFIX, 'group_id', testDocuments.productGroupsDocument)
+        expect(nextGroupId).to.eq(2)
       })
     })
 

--- a/app/lib/app/SecvisogramPage/View.js
+++ b/app/lib/app/SecvisogramPage/View.js
@@ -18,8 +18,8 @@ import ExportDocumentDialog from './View/ExportDocumentDialog.js'
 import schema from './View/FormEditor/schema.js'
 import RelevanceLevelContext from './View/FormEditor/shared/context/RelevanceLevelContext.js'
 import {
-  uniqueGroupId,
-  uniqueProductId,
+  useUniqueGroupId,
+  useUniqueProductId,
 } from './View/FormEditor/shared/fillFieldFunctions.js'
 import FormEditor from './View/FormEditorTab.js'
 import JsonEditorTab from './View/JsonEditorTab.js'
@@ -85,6 +85,8 @@ function View({
   const newDocumentDialogRef = React.useRef(
     /** @type {HTMLDialogElement | null} */ (null)
   )
+  const { resetProductIdCounter } = useUniqueProductId()
+  const { resetGroupIdCounter } = useUniqueGroupId()
 
   React.useEffect(() => {
     if (newDocumentDialog) {
@@ -526,8 +528,8 @@ function View({
           }}
           onConfirm={() => {
             setAlert(null)
-            uniqueProductId(true)
-            uniqueGroupId(true)
+            resetProductIdCounter()
+            resetGroupIdCounter()
             callback()
           }}
         />

--- a/app/lib/app/SecvisogramPage/View/FormEditor/editors/GenericEditor.js
+++ b/app/lib/app/SecvisogramPage/View/FormEditor/editors/GenericEditor.js
@@ -11,7 +11,7 @@ import {
   getCurrentReleaseDate,
   getInitialReleaseDate,
   getRelationshipName,
-  uniqueProductId,
+  useUniqueProductId,
 } from '../shared/fillFieldFunctions.js'
 import ArrayEditor from './GenericEditor/ArrayEditor.js'
 import CVSSV2Attribute from './GenericEditor/Attributes/CVSS2Attribute.js'
@@ -61,6 +61,7 @@ export default function Editor({
   const userInfo = React.useContext(UserInfoContext)
 
   const { doc, updateDoc, collectIds } = React.useContext(DocumentEditorContext)
+  const { uniqueProductId } = useUniqueProductId()
 
   const { handleError } = React.useContext(AppErrorContext)
 

--- a/app/lib/app/SecvisogramPage/View/FormEditor/editors/GenericEditor/ArrayEditor.js
+++ b/app/lib/app/SecvisogramPage/View/FormEditor/editors/GenericEditor/ArrayEditor.js
@@ -18,7 +18,7 @@ import AppConfigContext from '../../../../../shared/context/AppConfigContext.js'
 import UserInfoContext from '../../../../../shared/context/UserInfoContext.js'
 import { set } from 'lodash/fp.js'
 import pruneEmpty from '../../../../../shared/pruneEmpty.js'
-import getChildItem from './shared/getChildItem.js'
+import useChildItem from './shared/getChildItem.js'
 
 /**
  * @param {object} props
@@ -130,6 +130,7 @@ function Menu({ instancePath, level = 1, ...props }) {
   const { doc, errors, updateDoc, replaceDoc } = React.useContext(
     DocumentEditorContext
   )
+  const { getChildItem } = useChildItem()
 
   const { loginAvailable } = React.useContext(AppConfigContext)
   const userInfo = React.useContext(UserInfoContext)

--- a/app/lib/app/SecvisogramPage/View/FormEditor/editors/GenericEditor/ObjectEditor.js
+++ b/app/lib/app/SecvisogramPage/View/FormEditor/editors/GenericEditor/ObjectEditor.js
@@ -16,7 +16,7 @@ import DocumentEditorContext from '../../../shared/DocumentEditorContext.js'
 import { GenericEditor } from '../../editors.js'
 import RelevanceLevelContext from '../../shared/context/RelevanceLevelContext.js'
 import { getErrorTextColor } from '../GenericEditor.js'
-import getChildItem from './shared/getChildItem.js'
+import useChildItem from './shared/getChildItem.js'
 
 /**
  * @param {object} props
@@ -37,6 +37,7 @@ export default function ObjectEditor({
   const { selectedRelevanceLevel, relevanceLevels } = React.useContext(
     RelevanceLevelContext
   )
+  const { getChildItem } = useChildItem()
 
   const { loginAvailable } = React.useContext(AppConfigContext)
   const userInfo = React.useContext(UserInfoContext)

--- a/app/lib/app/SecvisogramPage/View/FormEditor/editors/GenericEditor/shared/getChildItem.js
+++ b/app/lib/app/SecvisogramPage/View/FormEditor/editors/GenericEditor/shared/getChildItem.js
@@ -1,35 +1,47 @@
-import { uniqueGroupId } from '../../../shared/fillFieldFunctions.js'
+import { useUniqueGroupId } from '../../../shared/fillFieldFunctions.js'
 
-/**
- * @param {import('../../../shared/types').Property} property
- */
-function getPrefilledObject(property) {
-  const uiType = property.metaData?.uiType
-  if (uiType === 'WITH_GENERATED_GROUP_ID') {
-    return { group_id: uniqueGroupId() }
-  }
-  let obj = {}
+function usePrefilledObject() {
+  const { uniqueGroupId } = useUniqueGroupId()
 
-  property.metaInfo.arrayType?.metaInfo.propertyList?.forEach((p) => {
-    if (p.metaData?.uiType === 'WITH_GENERATED_GROUP_ID') {
-      // @ts-ignore
-      obj[p.key] = { group_id: uniqueGroupId() }
+  /**
+   * @param {import('../../../shared/types').Property} property
+   */
+  const getPrefilledObject = (property) => {
+    const uiType = property.metaData?.uiType
+    if (uiType === 'WITH_GENERATED_GROUP_ID') {
+      return { group_id: uniqueGroupId() }
     }
-  })
+    let obj = {}
 
-  return obj
+    property.metaInfo.arrayType?.metaInfo.propertyList?.forEach((p) => {
+      if (p.metaData?.uiType === 'WITH_GENERATED_GROUP_ID') {
+        // @ts-ignore
+        obj[p.key] = { group_id: uniqueGroupId() }
+      }
+    })
+
+    return obj
+  }
+
+  return { getPrefilledObject }
 }
 
-/**
- * @param {import('../../../shared/types').Property} property
- * @param {string} childType
- */
-export default function getChildItem(property, childType) {
-  return childType === 'OBJECT'
-    ? getPrefilledObject(property)
-    : childType === 'ARRAY'
-    ? []
-    : childType === 'STRING'
-    ? ''
-    : null
+export default function useChildItem() {
+  const { getPrefilledObject } = usePrefilledObject()
+
+  /**
+   * @param {import('../../../shared/types').Property} property
+   * @param {string} childType
+   */
+  const getChildItem = (property, childType) => {
+    return childType === 'OBJECT'
+      ? getPrefilledObject(property)
+      : childType === 'ARRAY'
+      ? []
+      : childType === 'STRING'
+      ? ''
+      : null
+  }
+
+  return {getChildItem}
 }

--- a/app/lib/app/SecvisogramPage/View/FormEditor/shared/fillFieldFunctions.js
+++ b/app/lib/app/SecvisogramPage/View/FormEditor/shared/fillFieldFunctions.js
@@ -44,7 +44,7 @@ const getNextIdForPrefix = (prefix, idKey, doc) => {
     })
     .filter((id) => !!id)
 
-  const maxId = max(numberIds) || 0
+  const maxId = Math.max(max(numberIds) || 0, 0)
   return maxId + 1
 }
 
@@ -59,15 +59,16 @@ function useUniqueId(
   const [scanTrigger, setScanTrigger] = useState(false)
 
   const scanDoc = useCallback(() => {
-      counters[idKey] = getNextIdForPrefix(prefix, idKey, doc)
+    counters[idKey] = getNextIdForPrefix(prefix, idKey, doc)
   }, [prefix, idKey, doc])
 
+  // enable rescan trigger on reset
   const resetCounter = () => {
     counters[idKey] = 0
     setScanTrigger(true)
   }
 
-  // rescan document after reset
+  // rescan document after it changed if scan trigger is set
   useEffect(() => {
     if (scanTrigger) {
       scanDoc()
@@ -77,11 +78,12 @@ function useUniqueId(
 
   // scan document if idKey hasn't been scanned before
   useEffect(() => {
-    if (counters[idKey] === undefined || counters[idKey] === 0) {
+    if (counters[idKey] === undefined || counters[idKey] <= 0) {
       scanDoc()
     }
   }, [idKey, scanDoc])
 
+  // return current counter value and increment it for next usage
   const uniqueId = () => {
     const id = counters[idKey]
     counters[idKey] = id + 1 // increment counter
@@ -114,7 +116,7 @@ function useUniqueGroupId() {
  * @param {string[]} instancePath
  * @return {string}
  */
-const getBranchName = function (doc, instancePath) {
+const getBranchName = function(doc, instancePath) {
   /** @type {string[]} */
   let acc = []
 
@@ -138,7 +140,7 @@ const getBranchName = function (doc, instancePath) {
  * @param {() => Promise<void | { id: string; name: string; }[]>} collectProductIds
  * @return {Promise<string | undefined>}
  */
-const getRelationshipName = async function (
+const getRelationshipName = async function(
   doc,
   instancePath,
   collectProductIds
@@ -179,7 +181,7 @@ const getRelationshipName = async function (
  *
  * @return string|undefined
  */
-const getCurrentDateRounded = function () {
+const getCurrentDateRounded = function() {
   const p = 60 * 60 * 1000 // milliseconds in an hour
   const roundedDate = new Date(Math.ceil(new Date().getTime() / p) * p)
   return roundedDate.toISOString()
@@ -191,7 +193,7 @@ const getCurrentDateRounded = function () {
  * @param {Record<string, any>} doc
  * @return string|undefined
  */
-const getCurrentReleaseDate = function (doc) {
+const getCurrentReleaseDate = function(doc) {
   /** @type {{date: string, number: string}[]} */
   const revisionHistory = doc?.document?.tracking?.revision_history
   return revisionHistory
@@ -206,7 +208,7 @@ const getCurrentReleaseDate = function (doc) {
  * @param {Record<string, any>} doc
  * @return string|undefined
  */
-const getInitialReleaseDate = function (doc) {
+const getInitialReleaseDate = function(doc) {
   /** @type {{date: string, number: string}[]} */
   const revisionHistory = doc?.document?.tracking?.revision_history
   return revisionHistory?.filter(


### PR DESCRIPTION
# Changes
When a new document is loaded, it is now scanned for product and group ids, which are then used to initialize the counter of the according fill functions (magic wands).

The `uniqueProductId` and `uniqueGroupId` functions have been  wrapped by react hooks. This enables the usage of the document context, so the document doesn't have to be passed to the function everytime it is called.