### PR TITLE
add a hint for "profile" method

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ Setting the conent displayed in the sidebar is also possible by right-clicking o
 
 Note that multiline strings are not supported in JSON value fields and will break this navigation. To add line breaks type `\n` instead.
 
+The _JSON Editor_ enables users to generate a blueprint JSON file, such as for a vendor, containing essential details like `product id`, `publisher`. This JSON can be saved locally and later pasted into the editor to populate it with specific content, such as CVE details and the _Product Status_ for a VEX profile.
+
 [(back to top)](#bsi-secvisogram-csaf-20-web-editor)
 
 ### Preview (HTML view)

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Setting the conent displayed in the sidebar is also possible by right-clicking o
 
 Note that multiline strings are not supported in JSON value fields and will break this navigation. To add line breaks type `\n` instead.
 
-The _JSON Editor_ enables users to generate a blueprint JSON file, such as for a vendor, containing essential details like `product id`, `publisher`. This JSON can be saved locally and later pasted into the editor to populate it with specific content, such as CVE details and the _Product Status_ for a VEX profile.
+The _JSON Editor_ enables users to generate a blueprint JSON file, such as for a vendor, containing essential details like `product id` or `publisher`. This JSON can be saved locally and later pasted into the editor to populate it with specific content, such as CVE details and the _Product Status_ for a VEX profile.
 
 [(back to top)](#bsi-secvisogram-csaf-20-web-editor)
 


### PR DESCRIPTION
As a _vendor_, I aim to establish a _profile_ containing static information. In the event of a known vulnerability, I seek a streamlined process where I can simply input relevant details into the VEX profile and have the static information automatically populated. Since such functionality is currently unavailable, this serves as a lightweight approach to achieving it.