### PR TITLE
feat: add background to codeblocks

### DIFF
--- a/app/lib/app/SecvisogramPage/View/shared/HTMLTemplate.js
+++ b/app/lib/app/SecvisogramPage/View/shared/HTMLTemplate.js
@@ -75,7 +75,7 @@ const DOCUMENT_NOTE = `
 {{#text}}<p>{{{text}}}</p>{{/text}}`
 const ACKNOWLEDGEMENT = `
 {{#.}}
-  <li>{{#removeTrailingComma}}{{#names}}{{.}}, {{/names}}{{/removeTrailingComma}}{{#organization}}{{#names.length}} from {{/names.length}}{{.}} {{/organization}}{{#summary}} for {{.}}{{/summary}}{{#urls.length}} (see: {{#removeTrailingComma}}{{#urls}}{{> url}}, {{/urls}}{{/removeTrailingComma}}){{/urls.length}}</li>
+  <li>{{#removeTrailingComma}}{{#names}}{{.}}, {{/names}}{{/removeTrailingComma}}{{#organization}}{{#names.length}} from {{/names.length}}{{.}} {{/organization}}{{#summary}} for {{{.}}}{{/summary}}{{#urls.length}} (see: {{#removeTrailingComma}}{{#urls}}{{> url}}, {{/urls}}{{/removeTrailingComma}}){{/urls.length}}</li>
 {{/.}}`
 
 const REFERENCE = `

--- a/app/lib/app/SecvisogramPage/View/shared/HTMLTemplate/Template.html
+++ b/app/lib/app/SecvisogramPage/View/shared/HTMLTemplate/Template.html
@@ -4,6 +4,7 @@
 <head>
   <link rel="stylesheet" href="https://unpkg.com/gutenberg-css" charset="utf-8">
   <link rel="stylesheet" href="https://unpkg.com/gutenberg-css/dist/themes/modern.min.css" charset="utf-8">
+  <link rel="stylesheet" href="/preview.css" charset="utf-8">
   <meta charset="utf-8" />
 </head>
 

--- a/app/public/preview.css
+++ b/app/public/preview.css
@@ -1,0 +1,58 @@
+pre {
+  padding: 16px;
+  overflow: auto;
+  font-size: 85%;
+  line-height: 1.45;
+  color: #1F2328;
+  background-color: #f6f8fa !important;
+  border-radius: 6px;
+}
+
+h1 code,
+h2 code,
+h3 code,
+h4 code,
+h5 code,
+h6 code {
+  padding: 0 .2em;
+  font-size: inherit;
+}
+
+code {
+  padding: .2em .4em;
+  margin: 0;
+  font-size: 85%;
+  white-space: break-spaces;
+  background-color: rgba(175,184,193,0.2) !important;
+  border-radius: 6px;
+}
+
+code br {
+  display: none;
+}
+
+del code {
+  text-decoration: inherit;
+}
+
+pre>code {
+  padding: 0;
+  margin: 0;
+  word-break: normal;
+  white-space: pre;
+  background: transparent !important;
+  border: 0;
+}
+
+pre code {
+  font-size: 100%;
+  display: inline;
+  max-width: auto;
+  padding: 0;
+  margin: 0;
+  overflow: visible;
+  line-height: inherit;
+  word-wrap: normal;
+  background-color: transparent;
+  border: 0;
+}


### PR DESCRIPTION
# Changes
- preview styles were changed so that code blocks now have gray background. Styles were taken from the original [github markdown css](https://raw.githubusercontent.com/sindresorhus/github-markdown-css/main/github-markdown-light.css)
- fix: markdown html showing as text for acknowledgment summary