### PR TITLE
fix: clearing autocomplete produces null value

### DIFF
--- a/app/lib/app/SecvisogramPage/View/FormEditor/editors/GenericEditor/Attributes/DropdownAttribute.js
+++ b/app/lib/app/SecvisogramPage/View/FormEditor/editors/GenericEditor/Attributes/DropdownAttribute.js
@@ -39,11 +39,11 @@ export default function DropdownAttribute({
             options={options}
             freeSolo={!isEnum}
             value={value}
-            onChange={(event, newValue) =>
-              updateDoc(props.instancePath, /** @type {string} */ (newValue))
-            }
+            onChange={(_, newValue) => {
+              updateDoc(props.instancePath, /** @type {string} */(newValue ?? ''))
+            }}
             inputValue={/** @type {string} */ (inputValue)}
-            onInputChange={(event, newInputValue) => {
+            onInputChange={(_, newInputValue) => {
               setInputValue(newInputValue ?? '')
             }}
             onBlur={() => {


### PR DESCRIPTION
Fixes https://github.com/secvisogram/secvisogram/issues/534

# Changes
- Prevent doc update with null value (mui autocomplete returns null value after clearing)