### PR TITLE
feat(export): #629 - export - change saveInvalidDescription

### DIFF
--- a/app/locales/en/translation.json
+++ b/app/locales/en/translation.json
@@ -107,7 +107,7 @@
     "yesCreate": "Yes, create new document",
     "noResume": "No, resume editing",
     "saveInvalidTitle": "Validation",
-    "saveInvalidDescription": "Open validation issues: Your document is not yet CSAF 2.0 compliant!",
+    "saveInvalidDescription": "Open validation issues: Your document is not yet compliant to the selected CSAF version!",
     "saveInvalidCancel": "Resume editing (Recommended)",
     "saveInvalidConfirm": "Save invalid document",
     "theDocumentIsValid": "The document is valid!",


### PR DESCRIPTION
The export to HTML and PDF works. It is the same functionality as in the preview.
The export to CSAF Json and CSAF Json (stripped) works also.

Solves: https://github.com/secvisogram/secvisogram/issues/629