### PR TITLE
Feat/advisory pagination

### DIFF
--- a/app/cypress/e2e/SecvisogramPage.cy.js
+++ b/app/cypress/e2e/SecvisogramPage.cy.js
@@ -9,7 +9,7 @@ import { getLoginEnabledConfig } from '../fixtures/appConfigData.js'
 import {
   getAdvisories,
   getCreateAdvisoryResponse,
-  getGetAdvisoriesResponse,
+  getGetAdvisoriesPageResponse,
   getGetAdvisoryDetailResponse,
   getGetTemplateContentResponse,
   getGetTemplatesResponse,
@@ -197,9 +197,14 @@ describe('SecvisogramPage', () => {
               getLoginEnabledConfig().userInfoUrl,
               getUserInfo(user),
             ).as('apiGetUserInfo')
-            cy.intercept('/api/v1/advisories', getGetAdvisoriesResponse()).as(
-              'apiGetAdvisories',
-            )
+            cy.intercept(
+              {
+                method: 'GET',
+                pathname: '/api/v1/advisories',
+                query: { limit: '*' },
+              },
+              getGetAdvisoriesPageResponse(),
+            ).as('apiGetAdvisories')
             const advisoryDetail = getGetAdvisoryDetailResponse({
               advisoryId,
             })
@@ -569,9 +574,14 @@ describe('SecvisogramPage', () => {
               getLoginEnabledConfig().userInfoUrl,
               getUserInfo(user),
             ).as('apiGetUserInfo')
-            cy.intercept('/api/v1/advisories', getGetAdvisoriesResponse()).as(
-              'apiGetAdvisories',
-            )
+            cy.intercept(
+              {
+                method: 'GET',
+                pathname: '/api/v1/advisories',
+                query: { limit: '*' },
+              },
+              getGetAdvisoriesPageResponse(),
+            ).as('apiGetAdvisories')
 
             const advisoryDetail = getGetAdvisoryDetailResponse({
               advisoryId: advisory.advisoryId,

--- a/app/cypress/e2e/SecvisogramPage/DocumentsTab.cy.js
+++ b/app/cypress/e2e/SecvisogramPage/DocumentsTab.cy.js
@@ -1,8 +1,10 @@
 import { getLoginEnabledConfig } from '../../fixtures/appConfigData.js'
 import {
+  asAdvisoriesPage,
   canCreateVersion,
   canDeleteDocument,
   getAdvisories,
+  getGetAdvisoriesPageResponse,
   getGetAdvisoriesResponse,
   getGetAdvisoryDetailResponse,
   getUserInfo,
@@ -15,9 +17,12 @@ describe('SecvisogramPage / DocumentsTab', function () {
       '/.well-known/appspecific/de.bsi.secvisogram.json',
       getLoginEnabledConfig(),
     ).as('wellKnownAppConfig')
-    cy.intercept('/api/v1/advisories', getGetAdvisoriesResponse()).as(
-      'apiGetAdvisories',
-    )
+    // The Documents tab requests the paginated endpoint:
+    // GET /api/v1/advisories?limit=50, answered with the page envelope.
+    cy.intercept(
+      { method: 'GET', pathname: '/api/v1/advisories', query: { limit: '*' } },
+      getGetAdvisoriesPageResponse(),
+    ).as('apiGetAdvisories')
   })
 
   describe('can fetch documents from the csaf cms backend', function () {
@@ -54,8 +59,12 @@ describe('SecvisogramPage / DocumentsTab', function () {
             getUserInfo(user),
           ).as('apiGetUserInfo')
           cy.intercept(
-            '/api/v1/advisories',
-            getGetAdvisoriesResponse(user.user),
+            {
+              method: 'GET',
+              pathname: '/api/v1/advisories',
+              query: { limit: '*' },
+            },
+            getGetAdvisoriesPageResponse(user.user),
           ).as('apiGetAdvisories')
           const advisoryDetail = getGetAdvisoryDetailResponse({
             advisoryId: advisory.advisoryId,
@@ -78,11 +87,19 @@ describe('SecvisogramPage / DocumentsTab', function () {
           cy.wait('@apiGetUserInfo')
           cy.wait('@apiGetAdvisories')
 
-          // Pretend to have the advisory removed
+          // Pretend to have the advisory removed. The post-delete refetch
+          // (onGetData) hits the paginated endpoint, so serve the filtered
+          // rows inside the page envelope.
           cy.intercept(
-            '/api/v1/advisories',
-            getGetAdvisoriesResponse().filter(
-              (a) => a.advisoryId !== advisory.advisoryId,
+            {
+              method: 'GET',
+              pathname: '/api/v1/advisories',
+              query: { limit: '*' },
+            },
+            asAdvisoriesPage(
+              getGetAdvisoriesResponse().filter(
+                (a) => a.advisoryId !== advisory.advisoryId,
+              ),
             ),
           ).as('apiGetAdvisories')
 
@@ -263,8 +280,12 @@ describe('SecvisogramPage / DocumentsTab', function () {
             getUserInfo(user),
           ).as('apiGetUserInfo')
           cy.intercept(
-            '/api/v1/advisories',
-            getGetAdvisoriesResponse(user.user),
+            {
+              method: 'GET',
+              pathname: '/api/v1/advisories',
+              query: { limit: '*' },
+            },
+            getGetAdvisoriesPageResponse(user.user),
           ).as('apiGetAdvisories')
           cy.intercept(
             `/api/v1/advisories/${advisory.advisoryId}`,

--- a/app/cypress/e2e/SecvisogramPage/DocumentsTabPagination.cy.js
+++ b/app/cypress/e2e/SecvisogramPage/DocumentsTabPagination.cy.js
@@ -1,0 +1,108 @@
+import { getLoginEnabledConfig } from '../../fixtures/appConfigData.js'
+import { getUserInfo } from '../../fixtures/cmsBackendData.js'
+
+const TOTAL_ADVISORIES = 271
+const PAGE_SIZE = 50
+
+/**
+ * Builds the full set of mocked advisories the paginated endpoint serves.
+ *
+ * @returns {Array<object>}
+ */
+function buildAllAdvisories() {
+  return Array.from({ length: TOTAL_ADVISORIES }, (_, index) => {
+    const id = `advisory-${String(index).padStart(4, '0')}`
+    return {
+      advisoryId: id,
+      revision: 'rev-1',
+      workflowState: 'Draft',
+      documentTrackingId: `tracking-${id}`,
+      title: `Advisory ${index}`,
+      owner: 'editor',
+      changeable: false,
+      deletable: false,
+      canCreateVersion: false,
+      allowedStateChanges: [],
+      currentReleaseDate: '2024-01-01T00:00:00.000Z',
+    }
+  })
+}
+
+/**
+ * Serves a single page of the advisory list per the page envelope.
+ * The bookmark encodes the next offset; it is null on the last page.
+ *
+ * @param {Array<object>} all
+ * @param {string | undefined} bookmark
+ * @param {number} limit
+ */
+function pageFor(all, bookmark, limit) {
+  const offset = bookmark ? Number(bookmark) : 0
+  const slice = all.slice(offset, offset + limit)
+  const nextOffset = offset + slice.length
+  const hasMore = nextOffset < all.length
+  return {
+    advisories: slice,
+    bookmark: hasMore ? String(nextOffset) : null,
+    hasMore,
+    limit,
+  }
+}
+
+describe('SecvisogramPage / DocumentsTab pagination', function () {
+  beforeEach(function () {
+    cy.intercept(
+      '/.well-known/appspecific/de.bsi.secvisogram.json',
+      getLoginEnabledConfig(),
+    ).as('wellKnownAppConfig')
+
+    cy.intercept(
+      getLoginEnabledConfig().userInfoUrl,
+      getUserInfo({
+        user: 'editor',
+        preferredUsername: 'editor',
+        email: '',
+        groups: ['editor', 'author'],
+      }),
+    ).as('apiGetUserInfo')
+
+    const all = buildAllAdvisories()
+    cy.intercept({ method: 'GET', url: '/api/v1/advisories*' }, (req) => {
+      const limit = Number(req.query.limit) || PAGE_SIZE
+      const bookmark =
+        typeof req.query.bookmark === 'string' ? req.query.bookmark : undefined
+      req.reply(pageFor(all, bookmark, limit))
+    }).as('apiGetAdvisories')
+  })
+
+  it('loads all advisories across pages via "Load more"', function () {
+    cy.visit('?tab=DOCUMENTS')
+    cy.wait('@wellKnownAppConfig')
+    cy.wait('@apiGetUserInfo')
+    cy.wait('@apiGetAdvisories')
+
+    // First page is rendered promptly.
+    cy.get('[data-testid$="-list_entry"]').should('have.length', PAGE_SIZE)
+
+    // Click "Load more" until it disappears (last page reached).
+    function loadRemaining() {
+      cy.get('body').then(($body) => {
+        const button = $body.find(
+          '[data-testid="advisory-list-load_more_button"]',
+        )
+        if (button.length === 0) return
+        cy.wrap(button).click()
+        cy.wait('@apiGetAdvisories')
+        loadRemaining()
+      })
+    }
+    loadRemaining()
+
+    // The "Load more" control is gone and every mocked row is rendered.
+    cy.get('[data-testid="advisory-list-load_more_button"]').should('not.exist')
+    cy.get('[data-testid$="-list_entry"]').should(
+      'have.length',
+      TOTAL_ADVISORIES,
+    )
+  })
+})

--- a/app/cypress/e2e/SecvisogramPage/FormEditorTab.cy.js
+++ b/app/cypress/e2e/SecvisogramPage/FormEditorTab.cy.js
@@ -4,7 +4,7 @@ import { getLoginEnabledConfig } from '../../fixtures/appConfigData.js'
 import {
   canChangeDocument,
   getAdvisories,
-  getGetAdvisoriesResponse,
+  getGetAdvisoriesPageResponse,
   getGetAdvisoryDetailResponse,
   getUserInfo,
   getUsers,
@@ -31,9 +31,12 @@ describe('SecvisogramPage / FormEditor Tab', function () {
             getUserInfo(user),
           ).as('apiGetUserInfo')
           cy.intercept(
-            'GET',
-            '/api/v1/advisories',
-            getGetAdvisoriesResponse(),
+            {
+              method: 'GET',
+              pathname: '/api/v1/advisories',
+              query: { limit: '*' },
+            },
+            getGetAdvisoriesPageResponse(),
           ).as('apiGetAdvisories')
 
           const advisoryDetail = getGetAdvisoryDetailResponse({

--- a/app/cypress/fixtures/cmsBackendData.js
+++ b/app/cypress/fixtures/cmsBackendData.js
@@ -65,6 +65,50 @@ export function getGetAdvisoriesResponse(userName) {
   }))
 }
 
+/**
+ * Wraps the bare advisory array in the paginated envelope.
+ *
+ * The Documents tab always sends `?limit=<n>` (default 50), so the backend
+ * always answers with the `AdvisoryDocumentInformationPage` envelope rather
+ * than a bare array. The Cypress fixture dataset fits on a single page, so
+ * `hasMore` is `false` and `bookmark` is `null`.
+ *
+ * @param {string} [userName]
+ * @param {number} [limit]
+ * @returns {{
+ *   advisories: ReturnType<typeof getGetAdvisoriesResponse>,
+ *   bookmark: null,
+ *   hasMore: false,
+ *   limit: number,
+ * }}
+ */
+export function getGetAdvisoriesPageResponse(userName, limit = 50) {
+  return {
+    advisories: getGetAdvisoriesResponse(userName),
+    bookmark: null,
+    hasMore: false,
+    limit,
+  }
+}
+
+/**
+ * Wraps an already-shaped bare advisory array in the single-page
+ * envelope. Use when a test needs to mutate the row set (e.g. simulate a
+ * deletion) before serving it as a page.
+ *
+ * @param {Array<object>} advisories
+ * @param {number} [limit]
+ * @returns {{
+ *   advisories: Array<object>,
+ *   bookmark: null,
+ *   hasMore: false,
+ *   limit: number,
+ * }}
+ */
+export function asAdvisoriesPage(advisories, limit = 50) {
+  return { advisories, bookmark: null, hasMore: false, limit }
+}
+
 export function getAdvisories() {
   return testsSample.advisories
 }

--- a/app/lib/app/SecvisogramPage/DocumentsTab.js
+++ b/app/lib/app/SecvisogramPage/DocumentsTab.js
@@ -5,7 +5,7 @@ import {
   createNewVersion,
   getAdvisoryDetail,
 } from '../shared/api/backend.js'
-import { deleteAdvisory, getData } from './DocumentsTab/service.js'
+import { deleteAdvisory, getData, getMoreData } from './DocumentsTab/service.js'
 import DocumentsTabView from './DocumentsTab/View.js'
 
 /** @typedef {React.ComponentProps<typeof DocumentsTabView>} ViewProps */
@@ -30,6 +30,7 @@ export default function DocumentsTab(props) {
     <DocumentsTabView
       {...props}
       onGetData={getData}
+      onGetMoreData={getMoreData}
       onDeleteAdvisory={deleteAdvisory}
       onChangeWorkflowState={async ({
         advisoryId,

--- a/app/lib/app/SecvisogramPage/DocumentsTab/View.js
+++ b/app/lib/app/SecvisogramPage/DocumentsTab/View.js
@@ -15,6 +15,7 @@ export default function DocumentsTabView({
   defaultData = null,
   onOpenAdvisory,
   onGetData,
+  onGetMoreData,
   onDeleteAdvisory,
   onChangeWorkflowState,
   onCreateNewVersion,
@@ -27,6 +28,34 @@ export default function DocumentsTabView({
   )
   const [data, setData] = React.useState(defaultData)
   const [isLoading, setLoading] = React.useState(!defaultData)
+  // Tracks only the in-flight "Load more" page so already-rendered rows stay
+  // visible while the next page loads.
+  const [isLoadingMore, setLoadingMore] = React.useState(false)
+
+  /**
+   * Loads the next page and appends its rows to the currently
+   * rendered list, keeping the already-loaded rows visible.
+   */
+  const onLoadMore = () => {
+    if (!data?.hasMore) return
+    setLoadingMore(true)
+    onGetMoreData({ bookmark: data.bookmark })
+      .then((nextPage) => {
+        setData((current) =>
+          current
+            ? {
+                advisories: [...current.advisories, ...nextPage.advisories],
+                bookmark: nextPage.bookmark,
+                hasMore: nextPage.hasMore,
+              }
+            : nextPage,
+        )
+      })
+      .catch(handleError)
+      .finally(() => {
+        setLoadingMore(false)
+      })
+  }
 
   const [editWorkflowStateDialogProps, setEditWorkflowStateDialogProps] =
     React.useState(
@@ -263,6 +292,19 @@ export default function DocumentsTabView({
                   ))}
                 </tbody>
               </table>
+              {data?.hasMore && (
+                <div className="flex justify-center py-4">
+                  <button
+                    className="underline disabled:opacity-50"
+                    type="button"
+                    data-testid="advisory-list-load_more_button"
+                    disabled={isLoadingMore}
+                    onClick={onLoadMore}
+                  >
+                    {isLoadingMore ? t('menu.loading') : t('menu.loadMore')}
+                  </button>
+                </div>
+              )}
             </div>
             {isLoading && <LoadingIndicator label="Loading ..." />}
           </>

--- a/app/lib/app/SecvisogramPage/DocumentsTab/View/types.ts
+++ b/app/lib/app/SecvisogramPage/DocumentsTab/View/types.ts
@@ -1,19 +1,29 @@
+interface Advisory {
+  advisoryId: string
+  title: string
+  owner: string
+  workflowState: string
+  allowedStateChanges: string[]
+  deletable: boolean
+  canCreateVersion: boolean
+  currentReleaseDate: string
+}
+
 interface Data {
-  advisories: Array<{
-    advisoryId: string
-    title: string
-    owner: string
-    workflowState: string
-    allowedStateChanges: string[]
-    deletable: boolean
-    canCreateVersion: boolean
-    currentReleaseDate: string
-  }>
+  advisories: Array<Advisory>
+  // Opaque cursor for the next page; null on the last page.
+  bookmark: string | null
+  // Whether another page exists; drives the "Load more" control.
+  hasMore: boolean
 }
 
 export interface Props {
   defaultData?: Data | null
-  onGetData(): Promise<Data>
+  onGetData(params?: { limit?: number }): Promise<Data>
+  onGetMoreData(params: {
+    bookmark: string | null
+    limit?: number
+  }): Promise<Data>
   onDeleteAdvisory(params: { advisoryId: string }): Promise<void>
   onOpenAdvisory(params: { advisoryId: string }, callback: () => void): void
   onChangeWorkflowState(params: {

--- a/app/lib/app/SecvisogramPage/DocumentsTab/service.js
+++ b/app/lib/app/SecvisogramPage/DocumentsTab/service.js
@@ -1,8 +1,57 @@
 import { backend } from '../../shared/api.js'
 
-export async function getData() {
-  const advisories = await backend.getAdvisories()
-  return { advisories }
+const DEFAULT_PAGE_SIZE = 50
+
+/**
+ * @typedef {object} AdvisoryPage
+ * @property {Array<any>} advisories
+ * @property {string | null} bookmark
+ * @property {boolean} hasMore
+ */
+
+/**
+ * Fetches the first page of advisories.
+ *
+ * @param {object} [params]
+ * @param {number} [params.limit] Page size; defaults to 50.
+ * @returns {Promise<AdvisoryPage>}
+ */
+export async function getData({ limit = DEFAULT_PAGE_SIZE } = {}) {
+  const page = await backend.getAdvisories({ limit })
+  return normalizePage(page)
+}
+
+/**
+ * Fetches a subsequent page of advisories, resuming from the given bookmark.
+ *
+ * @param {object} params
+ * @param {string | null} params.bookmark Opaque cursor from the previous page.
+ * @param {number} [params.limit] Page size; defaults to 50.
+ * @returns {Promise<AdvisoryPage>}
+ */
+export async function getMoreData({ bookmark, limit = DEFAULT_PAGE_SIZE }) {
+  const page = await backend.getAdvisories({ limit, bookmark })
+  return normalizePage(page)
+}
+
+/**
+ * Normalises the paginated envelope into the shape the Documents tab consumes.
+ * The per-row shape is passed through unchanged. Always called for a paginated
+ * request (a `limit` is always sent), so the response is always the envelope.
+ *
+ * @param {Array<any> | { advisories?: Array<any>, bookmark?: string | null, hasMore?: boolean }} response
+ * @returns {AdvisoryPage}
+ */
+function normalizePage(response) {
+  const page =
+    /** @type {{ advisories?: Array<any>, bookmark?: string | null, hasMore?: boolean }} */ (
+      response
+    )
+  return {
+    advisories: page.advisories ?? [],
+    bookmark: page.bookmark ?? null,
+    hasMore: page.hasMore ?? false,
+  }
 }
 
 /**

--- a/app/lib/app/shared/api/backend.js
+++ b/app/lib/app/shared/api/backend.js
@@ -153,8 +153,37 @@ export async function deleteAdvisory({ advisoryId, revision }) {
   ).send()
 }
 
-export async function getAdvisories() {
-  const res = await new CsrfApiRequest(new Request('/api/v1/advisories'))
+/**
+ * Fetches advisories from the CMS backend.
+ *
+ * Backward-compatible by design: called with no arguments (or
+ * without a `limit`) it preserves the legacy behaviour and resolves to the
+ * bare `AdvisoryDocumentInformation[]` array. When a `limit` is provided it
+ * opts into the paginated wire contract and resolves to the page envelope
+ * `{ advisories, bookmark, hasMore }`; pass the previous page's `bookmark`
+ * (opaque, echoed back verbatim) to fetch the next page.
+ *
+ * @param {object} [options]
+ * @param {number} [options.limit] Max visible rows per page (1–1000).
+ *   When omitted, the legacy bare-array response is returned.
+ * @param {string | null} [options.bookmark] Opaque cursor from the previous
+ *   page. Ignored unless `limit` is provided.
+ * @returns {Promise<
+ *   | Array<object>
+ *   | { advisories: Array<object>, bookmark: string | null, hasMore: boolean }
+ * >}
+ */
+export async function getAdvisories(options) {
+  let requestUrl = '/api/v1/advisories'
+  if (options && typeof options.limit === 'number') {
+    const apiURL = new URL('/api/v1/advisories', window.location.href)
+    apiURL.searchParams.set('limit', String(options.limit))
+    if (typeof options.bookmark === 'string') {
+      apiURL.searchParams.set('bookmark', options.bookmark)
+    }
+    requestUrl = apiURL.toString()
+  }
+  const res = await new CsrfApiRequest(new Request(requestUrl))
     .setContentType('application/json')
     .send()
   return await res.json()

--- a/app/locales/en/translation.json
+++ b/app/locales/en/translation.json
@@ -27,6 +27,7 @@
     "addListItem": "Add list item",
     "addSubItem": "Add sub item",
     "create": "Create",
+    "loadMore": "Load more",
     "reallyDeleteAdvisory": "Really delete this advisory? This action cannot be undone.",
     "uploadFromFilesystem": "Upload from filesystem",
     "useTemplate": "Use a template",


### PR DESCRIPTION
Implements #801

Currently there not more then 25 advisories displayed in the Documents Tab regardless of how many are in the Backend. The Root Cause is pagination used in the couchdb Storage Backend of csaf-cms-backend. There is a corresponding pull request in csaf-cms-backend. 