### PR TITLE
Consume backend error message from response body to display to the user

### DIFF
--- a/app/lib/app/SecvisogramPage/DocumentsTab.js
+++ b/app/lib/app/SecvisogramPage/DocumentsTab.js
@@ -45,8 +45,10 @@ export default function DocumentsTab(props) {
           documentTrackingStatus,
           proposedTime,
         }).catch((err) => {
-          const message = messageForStatus(err.status)
-          throw new Error(message)
+          if (err.hasBackendMessage) {
+            throw err
+          }
+          throw new Error(messageForStatus(err.status))
         })
       }}
       onCreateNewVersion={async ({ advisoryId }) => {

--- a/app/lib/app/shared/ApiRequest.js
+++ b/app/lib/app/shared/ApiRequest.js
@@ -46,12 +46,44 @@ export default class ApiRequest {
   async send() {
     const res = await fetch(this.request)
     if (!res.ok) {
+      const backendMessage = await ApiRequest.extractBackendMessage(res)
       /** @type {any} */
-      const error = new Error(res.statusText)
+      const error = new Error(backendMessage ?? res.statusText)
       error.status = res.status
+      error.hasBackendMessage = backendMessage != null
       throw error
     }
 
     return res
+  }
+
+  /**
+   * Extracts the backend's error message from the response body (which can be JSON or text/plain)
+   * Returns null in case that no message was passed or it could not be parsed.
+   * @param {Response} res
+   * @returns {Promise<string | null>}
+   */
+  static async extractBackendMessage(res) {
+    const contentType = res.headers.get('content-type') ?? ''
+    if (contentType.includes('application/json')) {
+      try {
+        const body = await res.json()
+        if (typeof body?.message === 'string' && body.message.trim()) {
+          return body.message
+        }
+      } catch {
+        // fall through
+      }
+    } else if (contentType.includes('text/plain')) {
+      try {
+        const text = await res.text()
+        if (text.trim()) {
+          return text
+        }
+      } catch {
+        // fall through
+      }
+    }
+    return null
   }
 }


### PR DESCRIPTION
Backend has started to pass domain error messages in the body of error responses. Use those messages when available and display them to the user instead of just displaying the raw http status text. E.g. "User has no permission to edit the advisory" instead of "Unauthorized".

Related PR: https://github.com/secvisogram/csaf-cms-backend/pull/262

<img width="652" height="332" alt="image" src="https://github.com/user-attachments/assets/5a00cefa-cdf3-4ead-af81-528ac5c1e5f6" />
