### PR TITLE
enhance pruning logic to retain boolean values

### DIFF
--- a/app/lib/app/shared/pruneEmpty.js
+++ b/app/lib/app/shared/pruneEmpty.js
@@ -8,7 +8,12 @@ import { isEmpty } from 'lodash/fp.js'
  * @type {({}) => {}}
  */
 export default function pruneEmpty(obj) {
-  if (typeof obj === 'string' || typeof obj === 'number' || obj === undefined)
+  if (
+    typeof obj === 'string' ||
+    typeof obj === 'number' ||
+    typeof obj === 'boolean' ||
+    obj === undefined
+  )
     return obj
   if (Array.isArray(obj)) return obj.map((item) => pruneEmpty(item))
   return {
@@ -16,7 +21,7 @@ export default function pruneEmpty(obj) {
       Object.entries(obj)
         .map(([key, value]) => [key, pruneEmpty(value)])
         .filter(([, v]) => {
-          return typeof v === 'number' || !isEmpty(v)
+          return typeof v === 'number' || typeof v === 'boolean' || !isEmpty(v)
         }),
     ),
   }

--- a/app/tests/unit/unitTests.test.js
+++ b/app/tests/unit/unitTests.test.js
@@ -123,6 +123,11 @@ describe('Unit Test Functions', function () {
       [{ a: {} }, {}],
       [{ a: { b: { c: {} } } }, {}],
       [{ a: { b: { c: { d: 123 } } } }, { a: { b: { c: { d: 123 } } } }],
+      // booleans must never be pruned, regardless of their value
+      [{ a: true }, { a: true }],
+      [{ a: false }, { a: false }],
+      [{ a: { b: false } }, { a: { b: false } }],
+      [{ a: [true, false] }, { a: [true, false] }],
       // special cases for arrays with elements identified as empty
       [{ a: [{}] }, { a: [{}] }],
       [{ a: [''] }, { a: [''] }],


### PR DESCRIPTION
CSAF 2.1 introduced boolean values. In Secvisogram a `pruneEmpty` hook is executed every time a tab is switched. This pruning logic does not respect booleans. This PR fixes that.

Fixes #821 